### PR TITLE
Fix/36 마이페이지 - 활동 기록 null 오류 처리

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseRecordInfo.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseRecordInfo.kt
@@ -18,7 +18,7 @@ data class Record(
     val image: String,
     val machineId: String,
     val pace: String,
-    val publicCourseId: Int,
+    val publicCourseId: Int?,
     val time: String,
     val title: String
 )


### PR DESCRIPTION
서버에서 null을 담아 보내주는 publicCourseId의 타입을 nullable로 해주지 않아 발생한 이슈 해결

## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#40 마이페이지 - 활동 기록 null 오류 처리
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
서버에서 null을 담아 보내주는 publicCourseId의 타입을 nullable로 해주지 않아 발생한 이슈 해결

## 📸 스크린샷(선택)
<!-- 추가 설명이 필요한 경우 스크린샷을 첨부해주세요 -->
