### PR TITLE
Feature/67 코스그리기보관함마감

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/api/KCourseService.kt
+++ b/app/src/main/java/com/runnect/runnect/data/api/KCourseService.kt
@@ -9,12 +9,20 @@ import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.*
 
+
 interface KCourseService {
     //스크랩
     @POST("/api/scrap")
     suspend fun postCourseScrap(
         @Body requestCourseScrap: RequestCourseScrap,
     ): Response<ResponseCourseScrap>
+
+    // {id}와 같이 동적인 경로 변수가 없다면 @Path 생략 가능
+    //내가 그린 코스 수정
+    @PUT("/api/course")
+    suspend fun deleteMyDrawCourse(
+        @Body deleteCourseList: RequestPutMyDrawDto
+    ): Response<ResponsePutMyDrawDto>
 
     //보관함 내가 그린 코스 가져오기
     @GET("/api/course/user")

--- a/app/src/main/java/com/runnect/runnect/data/model/RequestPutMyDrawDto.kt
+++ b/app/src/main/java/com/runnect/runnect/data/model/RequestPutMyDrawDto.kt
@@ -1,0 +1,11 @@
+package com.runnect.runnect.data.model
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestPutMyDrawDto(
+    @SerialName("courseIdList")
+    val courseIdList: List<Long>
+)

--- a/app/src/main/java/com/runnect/runnect/data/model/ResponsePutMyDrawDto.kt
+++ b/app/src/main/java/com/runnect/runnect/data/model/ResponsePutMyDrawDto.kt
@@ -1,0 +1,23 @@
+package com.runnect.runnect.data.model
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponsePutMyDrawDto(
+    @SerialName("data")
+    val data: Data,
+    @SerialName("message")
+    val message: String,
+    @SerialName("status")
+    val status: Int,
+    @SerialName("success")
+    val success: Boolean
+) {
+    @Serializable
+    data class Data(
+        @SerialName("deletedCourseCount")
+        val deletedCourseCount: Int
+    )
+}

--- a/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
@@ -2,10 +2,7 @@ package com.runnect.runnect.presentation
 
 import android.os.Bundle
 import android.view.View
-import android.view.animation.Animation
-import android.view.animation.AnimationUtils
 import androidx.activity.viewModels
-import androidx.core.view.isVisible
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import com.runnect.runnect.R
@@ -25,6 +22,8 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     var isChangeToStorage: Boolean = false
     var isChangeToDiscover: Boolean = false
     var fromEndRunActivity: String? = ""
+    var fromDeleteMyDraw: Boolean = false
+    var fromDrawMyCourse: Boolean = false
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -67,8 +66,17 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
 
     private fun CheckIntentValue() {
-        isChangeToStorage =
-            intent.getBooleanExtra("fromDrawActivity", false)
+
+        fromDeleteMyDraw = intent.getBooleanExtra("fromDeleteMyDraw", false)
+        fromDrawMyCourse = intent.getBooleanExtra("fromDrawActivity", false)
+
+        if (fromDeleteMyDraw) {
+            isChangeToStorage = true
+        }
+
+        if (fromDrawMyCourse) {
+            isChangeToStorage = true
+        }
 
         isChangeToDiscover =
             intent.getBooleanExtra("fromScrapFragment", false)
@@ -82,7 +90,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             //아무것도 안 해도 됨. (fromDrawActivity == false) && (fromScrapFragment == false)이기만하면 courseMain을 띄우니까
         }
 
-        isChangeToStorage = intent.getBooleanExtra("fromDeleteMyDraw", false) //MyDrawDetail에서 삭제해서 넘어오는 경우
+
     }
 
     private fun addListener() {

--- a/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
@@ -81,6 +81,8 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         if (fromEndRunActivity == "draw") {
             //아무것도 안 해도 됨. (fromDrawActivity == false) && (fromScrapFragment == false)이기만하면 courseMain을 띄우니까
         }
+
+        isChangeToStorage = intent.getBooleanExtra("fromDeleteMyDraw", false) //MyDrawDetail에서 삭제해서 넘어오는 경우
     }
 
     private fun addListener() {

--- a/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     }
 
-    fun getBtmNaviMain(): View? {
+    fun getBottomNavMain(): View? {
         return findViewById(R.id.btm_navi_main)
     }
 

--- a/app/src/main/java/com/runnect/runnect/presentation/mydrawdetail/MyDrawDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mydrawdetail/MyDrawDetailActivity.kt
@@ -15,7 +15,10 @@ import com.runnect.runnect.R
 import com.runnect.runnect.data.model.MyDrawToRunData
 import com.runnect.runnect.data.model.ResponseGetMyDrawDetailDto
 import com.runnect.runnect.databinding.ActivityMyDrawDetailBinding
+import com.runnect.runnect.presentation.MainActivity
 import com.runnect.runnect.presentation.countdown.CountDownActivity
+import com.runnect.runnect.presentation.storage.StorageMainFragment
+import com.runnect.runnect.presentation.storage.StorageMyDrawFragment
 import kotlinx.android.synthetic.main.custom_dialog_delete.view.*
 import timber.log.Timber
 
@@ -25,6 +28,7 @@ class MyDrawDetailActivity :
 
     val viewModel: MyDrawDetailViewModel by viewModels()
 
+    val selectList = arrayListOf<Long>()
 
     lateinit var departureLatLng: LatLng
     private val touchList = arrayListOf<LatLng>()
@@ -53,7 +57,12 @@ class MyDrawDetailActivity :
         dialog.show()
 
         myLayout.btn_delete_yes.setOnClickListener {
+            deleteCourse()
             dialog.dismiss()
+            val intent = Intent(this, MainActivity::class.java).apply {
+                putExtra("fromDeleteMyDraw", true)
+            }
+            startActivity(intent)
         }
         myLayout.btn_delete_no.setOnClickListener {
             dialog.dismiss()
@@ -82,6 +91,8 @@ class MyDrawDetailActivity :
     fun getMyDrawDetail() {
         val courseId = intent.getIntExtra("fromStorageFragment", 0)
         Timber.tag(ContentValues.TAG).d("courseId from Storage : $courseId")
+
+        selectList.add(courseId.toLong()) //courseId를 지역변수로 선언해서 여기에 작성해주었음
         viewModel.getMyDrawDetail(courseId = courseId)
     }
 
@@ -142,6 +153,10 @@ class MyDrawDetailActivity :
             setTouchList(it)
             setPutExtraValue(it)
         }
+    }
+
+    fun deleteCourse() {
+        viewModel.deleteMyDrawCourse(selectList)
     }
 
 

--- a/app/src/main/java/com/runnect/runnect/presentation/mydrawdetail/MyDrawDetailViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mydrawdetail/MyDrawDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.runnect.runnect.presentation.mydrawdetail
 
+import android.content.ContentValues
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -7,9 +8,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.runnect.runnect.data.api.KApiCourse
 import com.runnect.runnect.data.model.MyDrawToRunData
+import com.runnect.runnect.data.model.RequestPutMyDrawDto
 import com.runnect.runnect.data.model.ResponseGetMyDrawDetailDto
 import com.runnect.runnect.presentation.state.UiState
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class MyDrawDetailViewModel : ViewModel() {
 
@@ -17,6 +20,7 @@ class MyDrawDetailViewModel : ViewModel() {
     val image = MutableLiveData<Uri>()
     val myDrawToRunData = MutableLiveData<MyDrawToRunData>()
     val courseId = MutableLiveData<Int>()
+
 
     private var _courseInfoState = MutableLiveData<UiState>(UiState.Loading)
     val courseInfoState: LiveData<UiState>
@@ -35,6 +39,23 @@ class MyDrawDetailViewModel : ViewModel() {
                 getResult.value = it.body()
             }.onFailure {
                 errorMessage.value = it.message
+            }
+        }
+    }
+
+    fun deleteMyDrawCourse(deleteList : MutableList<Long>) {
+        viewModelScope.launch {
+            runCatching {
+//                _storageState.value = UiState.Loading
+                service.deleteMyDrawCourse(RequestPutMyDrawDto(deleteList))
+            }.onSuccess {
+                Timber.tag(ContentValues.TAG)
+                    .d("삭제 성공입니다")
+//                _storageState.value = UiState.Success
+            }.onFailure {
+                Timber.tag(ContentValues.TAG)
+                    .d("실패했고 문제는 다음과 같습니다 $it")
+//                _storageState.value = UiState.Failure
             }
         }
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/report/ReportActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/report/ReportActivity.kt
@@ -100,6 +100,6 @@ class ReportActivity : com.runnect.runnect.binding.BindingActivity<ActivityLogin
     }
 
     companion object {
-        private const val DEFAULT_URL = "https://www.naver.com/"
+        private const val DEFAULT_URL = "https://docs.google.com/forms/d/e/1FAIpQLSek2rkClKfGaz1zwTEHX3Oojbq_pbF3ifPYMYezBU0_pe-_Tg/viewform"
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
@@ -1,5 +1,6 @@
 package com.runnect.runnect.presentation.storage
 
+import android.annotation.SuppressLint
 import android.app.AlertDialog
 import android.content.ContentValues
 import android.content.Intent
@@ -98,6 +99,7 @@ class StorageMyDrawFragment :
             showDeleteCourseBtn()
             // 총코스 TextView -> 코스 선택
             // btnEditCourse.isVisible = false
+            binding.tvTotalCourseCount.text = "코스 선택"
             isSelectAvailable = true
         }
     }
@@ -191,6 +193,7 @@ class StorageMyDrawFragment :
         binding.indeterminateBar.isVisible = false
     }
 
+    @SuppressLint("SetTextI18n")
     private fun showMyDrawResult() {
         Timber.tag(ContentValues.TAG)
             .d("Success but emptyList : ${viewModel.getMyDrawResult.value!!.data.courses.isEmpty()}")
@@ -201,6 +204,8 @@ class StorageMyDrawFragment :
                 tvStorageMyDrawNoCourseGuide2.isVisible = true
                 btnStorageNoCourse.isVisible = true
                 recyclerViewStorageMyDraw.isVisible = false
+                btnEditCourse.isEnabled = false
+                tvTotalCourseCount.text = "총 코스 ${viewModel.getMyDrawResult.value!!.data.courses.size}개"
             }
         } else {
             with(binding) {
@@ -209,6 +214,8 @@ class StorageMyDrawFragment :
                 tvStorageMyDrawNoCourseGuide2.isVisible = false
                 btnStorageNoCourse.isVisible = false
                 recyclerViewStorageMyDraw.isVisible = true
+                btnEditCourse.isEnabled = true
+                tvTotalCourseCount.text = "총 코스 ${viewModel.getMyDrawResult.value!!.data.courses.size}개"
             }
         }
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
@@ -127,9 +127,8 @@ class StorageMyDrawFragment :
 
 
         myLayout.btn_delete_yes.setOnClickListener {
-            removeItem() //currentList-selectList만 함 submitList를 옵저버로 처리하려고 이렇게 하는 거
-            viewModel.deleteMyDrawCourse(viewModel.selectList.value!!)
-//            storageMyDrawAdapter.removeItem(selectionTracker.selection)
+            removeItem()
+
             selectionTracker.clearSelection()
 
             initAdapter()
@@ -266,14 +265,11 @@ class StorageMyDrawFragment :
                     selectionTracker.clearSelection()
                 } //터치 활성화 여부
 
-//                binding.selected = selectionTracker.isSelected(itemId)
-
                 viewModel.selectList.value = selectionTracker.selection.toMutableList()
                 Timber.tag(ContentValues.TAG)
                     .d("실시간 뷰모델 selectList 값 : ${viewModel.selectList.value}")
 
                 val items = selectionTracker.selection.size()
-//                Log.d(ContentValues.TAG, "items 사이즈?: $items")
                 if (items == 0) {
                     disableSaveBtn()
                 } else if (items >= 1) {
@@ -312,48 +308,15 @@ class StorageMyDrawFragment :
         }
     }
 
-    fun observeCurrentList() { //삭제 버튼 누르면 뷰모델에 있는 currentList에서 삭제만 되게 해놓음
+    fun observeCurrentList() {
         viewModel.getMyDrawResult.observe(viewLifecycleOwner) {
-            //삭제가 됐다면 변화가 일어나서 이게 작동할 거고
+
             storageMyDrawAdapter.submitList(viewModel.getMyDrawResult.value!!.data.courses)
         }
     }
-// 지금 삭제 api에도 uiState를 넣어주었는데 이게 옵저버로 관찰 중이라
-    // 코스 삭제 통신을 실행시키는 순간 아래의 코드가 옵저버에 의해 자동으로 실행됨
-    //어쩌면 이게 문제였을 수도? getMyDrawResult는 최초 1번에 받아온 data를 저장해놓는 건데
-    //이걸 submitList하고 있었으니까. 삭제가 됐어도 갱신이 안 되는 거지.
-    //일단 삭제 코드에서 uistate 뺐음.
-
-//    private fun updateAdapterData() {
-//        storageMyDrawAdapter.submitList(viewModel.getMyDrawResult.value!!.data.courses)
-//    }
 
     fun removeItem() {
-        //select할 때마다 onSelectionChanged()가 실행되잖아.
-        //이걸 활용해서 터치가 일어날 때마다 뷰모델에 selectList 값 갱신
-        //삭제 버튼을 누르면 뷰모델에 저장해놓은 currentList 값에서 selectList 값 삭제
-        //이걸 옵저버로 관찰하게 하면 변화가 일어났으니 동작을 하겠지?
-        //변경된 currentList를 submitList하기.
-        viewModel.currentList.value = storageMyDrawAdapter.currentList.toMutableList()
-        Timber.tag(ContentValues.TAG)
-            .d("뷰모델 currentList 값 : ${viewModel.currentList.value!!.map { it.id }}")
-        val itemList = viewModel.currentList.value
-        val selectedIds = viewModel.selectList.value
-
-        Timber.tag(ContentValues.TAG).d("removeItem에서의 뷰모델 currentList 값 : ${itemList!!.map { it.id }}")
-        Timber.tag(ContentValues.TAG).d("removeItem에서의 뷰모델 selectList 값 : $selectedIds")
-
-        for (id in selectedIds!!) {
-            val index = itemList!!.indexOfFirst { it.id.toLong() == id.toLong() }
-            if (index != -1) {
-                itemList.removeAt(index)
-            }
-        }
-
-        viewModel.currentList.value = itemList
-
-        Timber.tag(ContentValues.TAG)
-            .d("삭제 후 뷰모델 currentList 값 : ${viewModel.currentList.value!!.map { it.id }}")
+        viewModel.deleteMyDrawCourse(viewModel.selectList.value!!)
     }
 
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
@@ -55,6 +55,41 @@ class StorageMyDrawFragment :
     var isSelectAvailable = false
 
 
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initLayout()
+        binding.lifecycleOwner = requireActivity()
+
+        initAdapter()
+        editCourse()
+        getCourse() //문제 없음
+        requireCourse() //상관 없음
+        addObserver()
+        addTrackerObserver() //selection
+        observeCurrentList()
+    }
+
+
+    private fun initAdapter() {
+        storageMyDrawAdapter = StorageMyDrawAdapter(this)
+        binding.recyclerViewStorageMyDraw.adapter = storageMyDrawAdapter
+    }
+
+
+    private fun initLayout() {
+        binding.recyclerViewStorageMyDraw
+            .layoutManager = GridLayoutManager(requireContext(), 2)
+        binding.recyclerViewStorageMyDraw.addItemDecoration(
+            GridSpacingItemDecoration(
+                requireContext(),
+                2,
+                6,
+                16
+            )
+        )
+    }
+
     private fun editCourse() {
         binding.btnEditCourse.setOnClickListener {
             //여기서 체크박스 visible로 바꾸고 터치 여부에 따라 setDrawble만 바뀌게
@@ -146,41 +181,6 @@ class StorageMyDrawFragment :
             dialog.dismiss()
         }
 
-    }
-
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        initLayout()
-        binding.lifecycleOwner = requireActivity()
-
-        initAdapter()
-        editCourse()
-        getCourse() //문제 없음
-        requireCourse() //상관 없음
-        addObserver()
-        addTrackerObserver() //selection
-        observeCurrentList()
-    }
-
-
-    private fun initAdapter() {
-        storageMyDrawAdapter = StorageMyDrawAdapter(this)
-        binding.recyclerViewStorageMyDraw.adapter = storageMyDrawAdapter
-    }
-
-
-    private fun initLayout() {
-        binding.recyclerViewStorageMyDraw
-            .layoutManager = GridLayoutManager(requireContext(), 2)
-        binding.recyclerViewStorageMyDraw.addItemDecoration(
-            GridSpacingItemDecoration(
-                requireContext(),
-                2,
-                6,
-                16
-            )
-        )
     }
 
     private fun showLoadingBar() {

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
@@ -28,6 +28,7 @@ import com.runnect.runnect.presentation.state.UiState
 import com.runnect.runnect.presentation.storage.adapter.StorageMyDrawAdapter
 import com.runnect.runnect.presentation.storage.adapter.setSelectionTracker
 import com.runnect.runnect.util.GridSpacingItemDecoration
+import com.runnect.runnect.util.callback.DeleteMyDrawCourse
 import com.runnect.runnect.util.callback.OnMyDrawClick
 import kotlinx.android.synthetic.main.custom_dialog_delete.view.*
 import timber.log.Timber
@@ -35,7 +36,7 @@ import timber.log.Timber
 
 class StorageMyDrawFragment :
     BindingFragment<FragmentStorageMyDrawBinding>(R.layout.fragment_storage_my_draw),
-    OnMyDrawClick {
+    OnMyDrawClick, DeleteMyDrawCourse {
 
     val viewModel: StorageViewModel by viewModels()
 
@@ -159,7 +160,7 @@ class StorageMyDrawFragment :
 
 
     private fun initAdapter() {
-        storageMyDrawAdapter = StorageMyDrawAdapter(this)
+        storageMyDrawAdapter = StorageMyDrawAdapter(this, this)
         binding.recyclerViewStorageMyDraw.adapter = storageMyDrawAdapter
     }
 
@@ -296,6 +297,11 @@ class StorageMyDrawFragment :
                 putExtra("fromStorageFragment", item.id)
             })
         }
+    }
+
+    override fun deleteCourse(deleteList: MutableList<Long>) {
+        viewModel.deleteMyDrawCourse(deleteList)
+        Timber.tag(ContentValues.TAG).d("삭제될 코스들 : $deleteList")
     }
 
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
@@ -93,6 +93,7 @@ class StorageMyDrawFragment :
         binding.btnEditCourse.setOnClickListener {
             if (!availableEdit) {
                 availableEdit = true
+                storageMyDrawAdapter.ableSelect()
                 hideBottomNav()
                 showDeleteCourseBtn()
                 binding.tvTotalCourseCount.text = "코스 선택"
@@ -100,6 +101,7 @@ class StorageMyDrawFragment :
                 isSelectAvailable = true
             } else {
                 availableEdit = false
+                storageMyDrawAdapter.disableSelect()
                 binding.btnEditCourse.text = "편집"
                 selectionTracker.clearSelection()
                 isSelectAvailable = false
@@ -168,6 +170,7 @@ class StorageMyDrawFragment :
             initAdapter()
             addSelectionTracker()
             getMyDrawCourse()
+            storageMyDrawAdapter.disableSelect()
             dialog.dismiss()
             isSelectAvailable = false
             hideDeleteCourseBtn()

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
@@ -127,13 +127,13 @@ class StorageMyDrawFragment :
 
 
         myLayout.btn_delete_yes.setOnClickListener {
-            removeItem()
+            deleteCourse()
 
             selectionTracker.clearSelection()
 
             initAdapter()
             addTrackerObserver()
-            
+
             viewModel.getMyDrawList()
 
             dialog.dismiss()
@@ -157,7 +157,7 @@ class StorageMyDrawFragment :
         initAdapter()
         editCourse()
         getCourse() //문제 없음
-        addData() //상관 없음
+        requireCourse() //상관 없음
         addObserver()
         addTrackerObserver() //selection
         observeCurrentList()
@@ -193,7 +193,7 @@ class StorageMyDrawFragment :
 
     private fun showMyDrawResult() {
         Timber.tag(ContentValues.TAG)
-            .d("통신 결과 코스 비어있나? : ${viewModel.getMyDrawResult.value!!.data.courses.isEmpty()}")
+            .d("Success but emptyList : ${viewModel.getMyDrawResult.value!!.data.courses.isEmpty()}")
         if (viewModel.getMyDrawResult.value!!.data.courses.isEmpty()) {
             with(binding) {
                 ivStorageMyDrawNoCourse.isVisible = true
@@ -241,7 +241,7 @@ class StorageMyDrawFragment :
 
     }
 
-    private fun addData() {
+    private fun requireCourse() {
         binding.btnStorageNoCourse.setOnClickListener {
             val intent = Intent(activity, SearchActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
@@ -315,7 +315,7 @@ class StorageMyDrawFragment :
         }
     }
 
-    fun removeItem() {
+    fun deleteCourse() {
         viewModel.deleteMyDrawCourse(viewModel.selectList.value!!)
     }
 

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
@@ -56,7 +56,6 @@ class StorageMyDrawFragment :
     var isSelectAvailable = false
 
 
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initLayout()
@@ -91,16 +90,31 @@ class StorageMyDrawFragment :
         )
     }
 
+    @SuppressLint("SetTextI18n")
     private fun editCourse() {
+        var availableEdit = false
         binding.btnEditCourse.setOnClickListener {
-            //여기서 체크박스 visible로 바꾸고 터치 여부에 따라 setDrawble만 바뀌게
-            //참조로 가져와야 함.
-            hideBtmNavi()
-            showDeleteCourseBtn()
-            // 총코스 TextView -> 코스 선택
-            // btnEditCourse.isVisible = false
-            binding.tvTotalCourseCount.text = "코스 선택"
-            isSelectAvailable = true
+            if (!availableEdit) {
+                //여기서 체크박스 visible로 바꾸고 터치 여부에 따라 setDrawble만 바뀌게
+                //참조로 가져와야 함.
+                availableEdit = true
+                hideBtmNavi()
+                showDeleteCourseBtn()
+                // 총코스 TextView -> 코스 선택
+                // btnEditCourse.isVisible = false
+                binding.tvTotalCourseCount.text = "코스 선택"
+                binding.btnEditCourse.text = "취소"
+                isSelectAvailable = true
+            } else {
+                availableEdit = false
+                binding.btnEditCourse.text = "편집"
+                selectionTracker.clearSelection()
+                isSelectAvailable = false
+                hideDeleteCourseBtn()
+                showBtmNavi()
+                binding.tvTotalCourseCount.text =
+                    "총 코스 ${viewModel.getMyDrawResult.value!!.data.courses.size}개"
+            }
         }
     }
 
@@ -115,12 +129,12 @@ class StorageMyDrawFragment :
     }
 
     fun showBtmNavi() {
-        animUp = AnimationUtils.loadAnimation(context, R.anim.slide_out_up)
+//        animUp = AnimationUtils.loadAnimation(context, R.anim.slide_out_up)
 
         val btmNaviMain = mainActivity.getBtmNaviMain() as BottomNavigationView
 
         //Bottom visible
-        btmNaviMain.startAnimation(animUp)
+//        btmNaviMain.startAnimation(animUp)
         btmNaviMain.isVisible = true
     }
 
@@ -167,17 +181,14 @@ class StorageMyDrawFragment :
             deleteCourse()
 
             selectionTracker.clearSelection()
-
             initAdapter()
             addTrackerObserver()
-
             viewModel.getMyDrawList()
-
             dialog.dismiss()
 
-//            hideDeleteCourseBtn()
-//            showBtmNavi()
-            //삭제하기 누르면 다시 총코스 TextView랑 btnEditCourse.isVisible = true
+            isSelectAvailable = false
+            hideDeleteCourseBtn()
+            showBtmNavi()
         }
         myLayout.btn_delete_no.setOnClickListener {
             dialog.dismiss()
@@ -205,7 +216,8 @@ class StorageMyDrawFragment :
                 btnStorageNoCourse.isVisible = true
                 recyclerViewStorageMyDraw.isVisible = false
                 btnEditCourse.isEnabled = false
-                tvTotalCourseCount.text = "총 코스 ${viewModel.getMyDrawResult.value!!.data.courses.size}개"
+                tvTotalCourseCount.text =
+                    "총 코스 ${viewModel.getMyDrawResult.value!!.data.courses.size}개"
             }
         } else {
             with(binding) {
@@ -215,7 +227,8 @@ class StorageMyDrawFragment :
                 btnStorageNoCourse.isVisible = false
                 recyclerViewStorageMyDraw.isVisible = true
                 btnEditCourse.isEnabled = true
-                tvTotalCourseCount.text = "총 코스 ${viewModel.getMyDrawResult.value!!.data.courses.size}개"
+                tvTotalCourseCount.text =
+                    "총 코스 ${viewModel.getMyDrawResult.value!!.data.courses.size}개"
             }
         }
     }
@@ -324,6 +337,7 @@ class StorageMyDrawFragment :
 
     fun deleteCourse() {
         viewModel.deleteMyDrawCourse(viewModel.selectList.value!!)
+        binding.btnEditCourse.text = "편집"
     }
 
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageViewModel.kt
@@ -26,6 +26,7 @@ class StorageViewModel : ViewModel() {
     val errorMessage = MutableLiveData<String>()
     val itemSize = MutableLiveData<Int>()
 
+
     private var _storageState = MutableLiveData<UiState>(UiState.Empty)
     val storageState: LiveData<UiState>
         get() = _storageState

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageViewModel.kt
@@ -18,8 +18,8 @@ import timber.log.Timber
 class StorageViewModel : ViewModel() {
 
     val service = KApiCourse.ServicePool.courseService //객체 생성
-
-    val deleteMyDrawResult = MutableLiveData<ResponsePutMyDrawDto>()
+    val selectList = MutableLiveData<MutableList<Long>>()
+    val currentList =  MutableLiveData<MutableList<ResponseGetCourseDto.Data.Course>>()
 
     val getMyDrawResult = MutableLiveData<ResponseGetCourseDto>()
     val getScrapListResult = MutableLiveData<ResponseGetScrapDto>()
@@ -50,21 +50,19 @@ class StorageViewModel : ViewModel() {
         }
     }
 
-    fun deleteMyDrawCourse(deleteCourseList: MutableList<Long>) {
+    fun deleteMyDrawCourse(deleteList : MutableList<Long>) {
         viewModelScope.launch {
             runCatching {
-                _storageState.value = UiState.Loading
-                service.deleteMyDrawCourse(RequestPutMyDrawDto(deleteCourseList))
+//                _storageState.value = UiState.Loading
+                service.deleteMyDrawCourse(RequestPutMyDrawDto(deleteList))
             }.onSuccess {
-                deleteMyDrawResult.value = it.body()
                 Timber.tag(ContentValues.TAG)
                     .d("삭제 성공입니다")
-                _storageState.value = UiState.Success
+//                _storageState.value = UiState.Success
             }.onFailure {
                 Timber.tag(ContentValues.TAG)
                     .d("실패했고 문제는 다음과 같습니다 $it")
-                errorMessage.value = it.message
-                _storageState.value = UiState.Failure
+//                _storageState.value = UiState.Failure
             }
         }
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageViewModel.kt
@@ -7,8 +7,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.runnect.runnect.data.api.KApiCourse
 import com.runnect.runnect.data.dto.request.RequestCourseScrap
+import com.runnect.runnect.data.model.RequestPutMyDrawDto
 import com.runnect.runnect.data.model.ResponseGetCourseDto
 import com.runnect.runnect.data.model.ResponseGetScrapDto
+import com.runnect.runnect.data.model.ResponsePutMyDrawDto
 import com.runnect.runnect.presentation.state.UiState
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -16,6 +18,8 @@ import timber.log.Timber
 class StorageViewModel : ViewModel() {
 
     val service = KApiCourse.ServicePool.courseService //객체 생성
+
+    val deleteMyDrawResult = MutableLiveData<ResponsePutMyDrawDto>()
 
     val getMyDrawResult = MutableLiveData<ResponseGetCourseDto>()
     val getScrapListResult = MutableLiveData<ResponseGetScrapDto>()
@@ -40,6 +44,25 @@ class StorageViewModel : ViewModel() {
             }.onFailure {
                 Timber.tag(ContentValues.TAG)
                     .d("문제가 뭐냐 $it")
+                errorMessage.value = it.message
+                _storageState.value = UiState.Failure
+            }
+        }
+    }
+
+    fun deleteMyDrawCourse(deleteCourseList: MutableList<Long>) {
+        viewModelScope.launch {
+            runCatching {
+                _storageState.value = UiState.Loading
+                service.deleteMyDrawCourse(RequestPutMyDrawDto(deleteCourseList))
+            }.onSuccess {
+                deleteMyDrawResult.value = it.body()
+                Timber.tag(ContentValues.TAG)
+                    .d("삭제 성공입니다")
+                _storageState.value = UiState.Success
+            }.onFailure {
+                Timber.tag(ContentValues.TAG)
+                    .d("실패했고 문제는 다음과 같습니다 $it")
                 errorMessage.value = it.message
                 _storageState.value = UiState.Failure
             }

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageViewModel.kt
@@ -1,10 +1,8 @@
 package com.runnect.runnect.presentation.storage
 
+import android.annotation.SuppressLint
 import android.content.ContentValues
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import com.runnect.runnect.data.api.KApiCourse
 import com.runnect.runnect.data.dto.request.RequestCourseScrap
 import com.runnect.runnect.data.model.RequestPutMyDrawDto

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
@@ -2,6 +2,7 @@ package com.runnect.runnect.presentation.storage.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.databinding.library.baseAdapters.BR
 import androidx.recyclerview.selection.ItemDetailsLookup
 import androidx.recyclerview.selection.SelectionTracker
@@ -20,6 +21,14 @@ class StorageMyDrawAdapter(
 
 
     private lateinit var selectionTracker: SelectionTracker<Long>
+    lateinit var binding: ItemStorageMyDrawBinding
+
+    var checkAvailable: Boolean = false
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
+
 
     init {
         setHasStableIds(true)
@@ -52,7 +61,7 @@ class StorageMyDrawAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val binding = ItemStorageMyDrawBinding.inflate(inflater)
+        binding = ItemStorageMyDrawBinding.inflate(inflater)
 
         return ItemViewHolder(binding)
     }
@@ -62,14 +71,22 @@ class StorageMyDrawAdapter(
 
         with(holder) {
             binding.setVariable(BR.storageItem, getItem(position))
+            binding.ivCheckbox.isVisible = checkAvailable
             binding.root.setOnClickListener {
                 myDrawClickListener.selectItem(currentList[position])
                 selectionTracker.select(itemId) //이게 select을 실행시킴. 리사이클러뷰 아이템 고유 id 수집
             }
-
             binding.selected = selectionTracker.isSelected(itemId)
         }
 
+    }
+
+    fun ableSelect() {
+        checkAvailable = true
+    }
+
+    fun disableSelect() {
+        checkAvailable = false
     }
 
 

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
@@ -1,9 +1,7 @@
 package com.runnect.runnect.presentation.storage.adapter
 
 import android.content.ContentValues
-import android.util.Log
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.library.baseAdapters.BR
 import androidx.recyclerview.selection.ItemDetailsLookup
@@ -12,15 +10,18 @@ import androidx.recyclerview.selection.SelectionTracker
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.runnect.runnect.R
+import com.runnect.runnect.data.model.RequestPutMyDrawDto
 import com.runnect.runnect.data.model.ResponseGetCourseDto
-import com.runnect.runnect.data.model.ResponseGetScrapDto
 import com.runnect.runnect.databinding.ItemStorageMyDrawBinding
+import com.runnect.runnect.util.callback.DeleteMyDrawCourse
 import com.runnect.runnect.util.callback.OnMyDrawClick
 import timber.log.Timber
 
 
-class StorageMyDrawAdapter(val myDrawClickListener: OnMyDrawClick) :
+class StorageMyDrawAdapter(
+    val myDrawClickListener: OnMyDrawClick,
+    val deleteCourseListener: DeleteMyDrawCourse
+) :
     ListAdapter<ResponseGetCourseDto.Data.Course, StorageMyDrawAdapter.ItemViewHolder>(Differ()) {
 
 
@@ -79,10 +80,16 @@ class StorageMyDrawAdapter(val myDrawClickListener: OnMyDrawClick) :
         }
 
     }
+
     fun removeItem(selection: Selection<Long>) {
         val itemList = currentList.toMutableList()
         val selectedIds = selection.toMutableList()
 
+        Timber.tag(ContentValues.TAG)
+            .d("selectedIds 값 : $selectedIds")
+
+        //화면에서 지우는 거랑 이걸 서버에 반영해주는 거랑 별개야
+        //이렇게 하면 화면에선 지운 거고 인터페이스로
         for (id in selectedIds) {
             val index = itemList.indexOfFirst { it.id.toLong() == id.toLong() }
             if (index != -1) {
@@ -90,8 +97,9 @@ class StorageMyDrawAdapter(val myDrawClickListener: OnMyDrawClick) :
             }
         }
         submitList(itemList)
-    }
 
+        deleteCourseListener.deleteCourse(selectedIds)
+    }
 
 
     class Differ : DiffUtil.ItemCallback<ResponseGetCourseDto.Data.Course>() {

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
@@ -1,21 +1,16 @@
 package com.runnect.runnect.presentation.storage.adapter
 
-import android.content.ContentValues
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.library.baseAdapters.BR
 import androidx.recyclerview.selection.ItemDetailsLookup
-import androidx.recyclerview.selection.Selection
 import androidx.recyclerview.selection.SelectionTracker
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.runnect.runnect.data.model.RequestPutMyDrawDto
 import com.runnect.runnect.data.model.ResponseGetCourseDto
 import com.runnect.runnect.databinding.ItemStorageMyDrawBinding
-import com.runnect.runnect.util.callback.DeleteMyDrawCourse
 import com.runnect.runnect.util.callback.OnMyDrawClick
-import timber.log.Timber
 
 
 class StorageMyDrawAdapter(
@@ -76,7 +71,6 @@ class StorageMyDrawAdapter(
         }
 
     }
-
 
 
     class Differ : DiffUtil.ItemCallback<ResponseGetCourseDto.Data.Course>() {

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
@@ -19,8 +19,7 @@ import timber.log.Timber
 
 
 class StorageMyDrawAdapter(
-    val myDrawClickListener: OnMyDrawClick,
-    val deleteCourseListener: DeleteMyDrawCourse
+    val myDrawClickListener: OnMyDrawClick
 ) :
     ListAdapter<ResponseGetCourseDto.Data.Course, StorageMyDrawAdapter.ItemViewHolder>(Differ()) {
 
@@ -98,7 +97,6 @@ class StorageMyDrawAdapter(
         }
         submitList(itemList)
 
-        deleteCourseListener.deleteCourse(selectedIds)
     }
 
 

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/adapter/StorageMyDrawAdapter.kt
@@ -71,33 +71,12 @@ class StorageMyDrawAdapter(
                 myDrawClickListener.selectItem(currentList[position])
                 selectionTracker.select(itemId) //이게 select을 실행시킴. 리사이클러뷰 아이템 고유 id 수집
             }
-            Timber.tag(ContentValues.TAG)
-                .d("selection 값 : ${selectionTracker.selection}")
-            Timber.tag(ContentValues.TAG)
-                .d("getItemId 값 : $itemId")
+
             binding.selected = selectionTracker.isSelected(itemId)
         }
 
     }
 
-    fun removeItem(selection: Selection<Long>) {
-        val itemList = currentList.toMutableList()
-        val selectedIds = selection.toMutableList()
-
-        Timber.tag(ContentValues.TAG)
-            .d("selectedIds 값 : $selectedIds")
-
-        //화면에서 지우는 거랑 이걸 서버에 반영해주는 거랑 별개야
-        //이렇게 하면 화면에선 지운 거고 인터페이스로
-        for (id in selectedIds) {
-            val index = itemList.indexOfFirst { it.id.toLong() == id.toLong() }
-            if (index != -1) {
-                itemList.removeAt(index)
-            }
-        }
-        submitList(itemList)
-
-    }
 
 
     class Differ : DiffUtil.ItemCallback<ResponseGetCourseDto.Data.Course>() {

--- a/app/src/main/java/com/runnect/runnect/util/callback/DeleteMyDrawCourse.kt
+++ b/app/src/main/java/com/runnect/runnect/util/callback/DeleteMyDrawCourse.kt
@@ -1,0 +1,7 @@
+package com.runnect.runnect.util.callback
+
+import com.runnect.runnect.data.model.RequestPutMyDrawDto
+
+interface DeleteMyDrawCourse {
+    fun deleteCourse(deleteList: MutableList<Long>)
+}

--- a/app/src/main/res/drawable/shape_address_bar.xml
+++ b/app/src/main/res/drawable/shape_address_bar.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="@color/G2"/>
+    <solid android:color="@color/G4"/>
     <corners android:radius="16dp"/>
 
 </shape>

--- a/app/src/main/res/layout/fragment_storage_my_draw.xml
+++ b/app/src/main/res/layout/fragment_storage_my_draw.xml
@@ -21,12 +21,12 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="15dp"
             android:fontFamily="@font/pretendard_light"
-            android:text="총 코스 152개"
             android:textColor="@color/G2"
             android:textSize="12sp"
             app:layout_constraintBottom_toBottomOf="@+id/btn_edit_course"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/btn_edit_course" />
+            app:layout_constraintTop_toTopOf="@id/btn_edit_course"
+            tools:text="총 코스 152개" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_edit_course"

--- a/app/src/main/res/layout/fragment_storage_my_draw.xml
+++ b/app/src/main/res/layout/fragment_storage_my_draw.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -9,49 +10,62 @@
             type="com.runnect.runnect.data.model.ResponseGetCourseDto" />
     </data>
 
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/tv_total_course_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="15dp"
-            android:fontFamily="@font/pretendard_light"
-            android:text="총 코스 152개"
-            android:textColor="@color/G2"
-            android:textSize="12sp"
-            app:layout_constraintBottom_toBottomOf="@+id/btn_edit_course"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/btn_edit_course" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/btn_edit_course"
-            android:layout_width="50dp"
-            android:layout_height="28dp"
-            android:layout_marginTop="7dp"
-            android:layout_marginEnd="15dp"
-            android:background="@drawable/radius_50_edit_course_button"
-            android:fontFamily="@font/pretendard_medium"
-            android:text="@string/my_draw_edit"
-            android:textColor="@color/M1"
-            android:textSize="12sp"
-            app:layout_constraintBottom_toTopOf="@id/scrollview_my_draw"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-
-        <ScrollView
-            android:id="@+id/scrollview_my_draw"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/fix_constraintLayout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginTop="7dp"
-            app:layout_constraintTop_toBottomOf="@id/btn_edit_course">
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/tv_total_course_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="15dp"
+                android:fontFamily="@font/pretendard_light"
+                android:text="총 코스 152개"
+                android:textColor="@color/G2"
+                android:textSize="12sp"
+                app:layout_constraintBottom_toBottomOf="@+id/btn_edit_course"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/btn_edit_course" />
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_edit_course"
+                android:layout_width="50dp"
+                android:layout_height="28dp"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="15dp"
+                android:layout_marginBottom="5dp"
+                android:background="@drawable/radius_50_edit_course_button"
+                android:fontFamily="@font/pretendard_medium"
+                android:text="@string/my_draw_edit"
+                android:textColor="@color/M1"
+                android:textSize="12sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/fix_constraintLayout">
 
             <androidx.constraintlayout.widget.ConstraintLayout
+
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="match_parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/fix_constraintLayout">
 
                 <ProgressBar
                     android:id="@+id/indeterminateBar"
@@ -67,6 +81,7 @@
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <androidx.recyclerview.widget.RecyclerView
+                    tools:listitem="@layout/item_storage_my_draw"
                     android:id="@+id/recyclerView_storage_my_draw"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
@@ -75,7 +90,6 @@
                     android:paddingBottom="20dp"
                     android:visibility="visible"
                     app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
@@ -111,8 +125,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="1dp"
-                    android:visibility="invisible"
                     android:text="직접 코스를 그려주세요"
+                    android:visibility="invisible"
                     app:layout_constraintEnd_toEndOf="@id/tv_storage_my_draw_no_course_guide"
                     app:layout_constraintStart_toStartOf="@id/tv_storage_my_draw_no_course_guide"
                     app:layout_constraintTop_toBottomOf="@id/tv_storage_my_draw_no_course_guide" />
@@ -133,10 +147,8 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_storage_my_draw_no_course_guide_2" />
 
-
             </androidx.constraintlayout.widget.ConstraintLayout>
-
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_storage_my_draw.xml
+++ b/app/src/main/res/layout/fragment_storage_my_draw.xml
@@ -15,57 +15,46 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/fix_constraintLayout"
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/tv_total_course_count"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_marginStart="15dp"
+            android:fontFamily="@font/pretendard_light"
+            android:text="총 코스 152개"
+            android:textColor="@color/G2"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_edit_course"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/btn_edit_course" />
 
-            <TextView
-                android:id="@+id/tv_total_course_count"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="15dp"
-                android:fontFamily="@font/pretendard_light"
-                android:text="총 코스 152개"
-                android:textColor="@color/G2"
-                android:textSize="12sp"
-                app:layout_constraintBottom_toBottomOf="@+id/btn_edit_course"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/btn_edit_course" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/btn_edit_course"
-                android:layout_width="50dp"
-                android:layout_height="28dp"
-                android:layout_marginTop="5dp"
-                android:layout_marginEnd="15dp"
-                android:layout_marginBottom="5dp"
-                android:background="@drawable/radius_50_edit_course_button"
-                android:fontFamily="@font/pretendard_medium"
-                android:text="@string/my_draw_edit"
-                android:textColor="@color/M1"
-                android:textSize="12sp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_edit_course"
+            android:layout_width="50dp"
+            android:layout_height="28dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="15dp"
+            android:background="@drawable/radius_50_edit_course_button"
+            android:fontFamily="@font/pretendard_medium"
+            android:text="@string/my_draw_edit"
+            android:textColor="@color/M1"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toTopOf="@id/nestedScrollView"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/nestedScrollView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/fix_constraintLayout">
+            app:layout_constraintTop_toBottomOf="@id/btn_edit_course">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/fix_constraintLayout">
+                android:layout_height="match_parent">
 
                 <ProgressBar
                     android:id="@+id/indeterminateBar"
@@ -81,7 +70,6 @@
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <androidx.recyclerview.widget.RecyclerView
-                    tools:listitem="@layout/item_storage_my_draw"
                     android:id="@+id/recyclerView_storage_my_draw"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
@@ -92,7 +80,8 @@
                     app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:listitem="@layout/item_storage_my_draw" />
 
                 <ImageView
                     android:id="@+id/iv_storage_my_draw_no_course"

--- a/app/src/main/res/layout/fragment_storage_scrap.xml
+++ b/app/src/main/res/layout/fragment_storage_scrap.xml
@@ -29,7 +29,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:id="@+id/scrollview_scrap"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -124,6 +124,6 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_storage_scrap.xml
+++ b/app/src/main/res/layout/fragment_storage_scrap.xml
@@ -22,7 +22,6 @@
             android:layout_marginTop="11dp"
             android:fontFamily="@font/pretendard_light"
             android:paddingBottom="11dp"
-            android:text="총 코스 152개"
             android:textColor="@color/G2"
             android:textSize="12sp"
             app:layout_constraintBottom_toTopOf="@id/scrollview_scrap"

--- a/app/src/main/res/layout/item_storage_my_draw.xml
+++ b/app/src/main/res/layout/item_storage_my_draw.xml
@@ -65,7 +65,7 @@
                 android:layout_height="wrap_content"
                 android:elevation="3dp"
                 android:outlineProvider="none"
-                android:visibility="visible"
+                android:visibility="invisible"
                 app:image_check="@{selected}"
                 app:scale_height="20"
                 app:scale_left="8"


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#67 코스그리기보관함마감
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 스크랩 상세페이지 -> CountDown data 전달 (실수로 develop 브랜치에서 바로 작업해서 올려버렸음)
- 웹뷰 구현
- 내가그린코스 다중 삭제 구현
- 내가그린코스 상세페이지에서 삭제 시 보관함으로 이동하게 함
- 편집 버튼 터치 시 체크박스 띄우고 item 선택이 가능하게 함
- 선택된 item 개수를 화면에 표시
- 편집 가능 여부에 따라 버튼 enable 속성 조절 
- 화면 상단에 가이드뷰 (ex. 터치로 코스를 그려보세요) 추가

## ✨ 고민되는 내용
**1. 편집 버튼 터치 시 체크박스 띄우는 logic에 notifySetDataChanged()를 쓴 것**
ListAdapter를 사용하는만큼 submitList를 쓰고싶었으나 submitList를 쓸 경우 기능이 제대로 작동하지 않음.
개인적인 생각으로는 지금 짜놓은 DiffUtil이 data들의 id값을 비교해서 변화를 감지하는 식인데
편집 버튼 터치로 체크박스를 띄우는 상황은 data는 그대로인데 UI만 업데이트하는 거라 DiffUtil이 안 먹히는 것 같음.
그래서 변화 여부에 관계없이 그냥 전체를 새로 그려버리는 notifySetDataChanged()를 썼는데 아무래도 전체를 다시 그리는 거라 비효율적인 것 같아서 고민이 됨.  


**2. 내가그린코스 다중 삭제할 때마다 어댑터 초기화**
한 번 삭제하고나면 인덱스가 밀려서 isSelected도 제대로 적용 안 되고 인덱스 에러 떠서 앱도 죽길래 아예 삭제할 때마다 어댑터를 초기화하고 data도 매번 새로 받아와서 이런 문제 자체가 안 생기게 구현을 했음. 그런데 아무래도 삭제할 때마다 어댑터를 초기화하고 전체 data를 매번 새로 받아오는 게 부담이 됨. 지금이야 data 개수가 적으니 사용성에 큰 영향이 없지만 만약 data가 많은 상황이라면 그만큼 delay가 생겨서 성능도 떨어지고 안 깔끔하지 않을까 하는 고민이 듦. 
*좀 더 고민해보고 안 되면 그냥 selection 라이브러리를 버리는 방법도 고려중

## 📸 스크린샷(선택)
<!-- 추가 설명이 필요한 경우 스크린샷을 첨부해주세요 -->

https://user-images.githubusercontent.com/89737271/235883079-f519a150-24fb-4372-9ddf-952f4c693332.mp4

