### PR TITLE
Feature/105 마이페이지 설정 계정 정보 뷰 작업

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/api/PUserService.kt
+++ b/app/src/main/java/com/runnect/runnect/data/api/PUserService.kt
@@ -45,4 +45,7 @@ interface PUserService {
         @Path("recordId") historyId: Int,
         @Body requestEditHistoryTitle: RequestEditHistoryTitle
     ): ResponseEditHistoryTitle
+
+    @DELETE("api/user")
+    suspend fun deleteUser(): ResponseDeleteUser
 }

--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseDeleteUser.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseDeleteUser.kt
@@ -1,0 +1,22 @@
+package com.runnect.runnect.data.dto.response
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserDeleteData(
+    @SerializedName("deletedUserId")
+    val deletedUserId: Int
+)
+
+@Serializable
+data class ResponseDeleteUser(
+    @SerializedName("data")
+    val `data`: UserDeleteData,
+    @SerializedName("message")
+    val message: String,
+    @SerializedName("status")
+    val status: Int,
+    @SerializedName("success")
+    val success: Boolean
+)

--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseUser.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseUser.kt
@@ -17,6 +17,7 @@ data class Data(
 
 @Serializable
 data class User(
+    val email:String,
     val latestStamp: String,
     val level: Int,
     val levelPercent: Int,

--- a/app/src/main/java/com/runnect/runnect/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/runnect/runnect/data/repository/UserRepositoryImpl.kt
@@ -54,4 +54,8 @@ class UserRepositoryImpl(private val userDataSource: UserDataSource) : UserRepos
     ): ResponseEditHistoryTitle {
         return userDataSource.patchHistoryTitle(historyId, requestEditHistoryTitle)
     }
+
+    override suspend fun deleteUser(): ResponseDeleteUser {
+        return userDataSource.deleteUser()
+    }
 }

--- a/app/src/main/java/com/runnect/runnect/data/source/remote/UserDataSource.kt
+++ b/app/src/main/java/com/runnect/runnect/data/source/remote/UserDataSource.kt
@@ -21,4 +21,5 @@ class UserDataSource(private val userService: PUserService) {
         userService.putDeleteUploadCourse(requestDeleteUploadCourse)
     suspend fun patchHistoryTitle(historyId:Int, requestEditHistoryTitle: RequestEditHistoryTitle): ResponseEditHistoryTitle =
         userService.patchHistoryTitle(historyId, requestEditHistoryTitle)
+    suspend fun deleteUser():ResponseDeleteUser = userService.deleteUser()
 }

--- a/app/src/main/java/com/runnect/runnect/domain/UserRepository.kt
+++ b/app/src/main/java/com/runnect/runnect/domain/UserRepository.kt
@@ -20,4 +20,6 @@ interface UserRepository {
         historyId: Int,
         requestEditHistoryTitle: RequestEditHistoryTitle
     ): ResponseEditHistoryTitle
+
+    suspend fun deleteUser(): ResponseDeleteUser
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
@@ -11,7 +11,6 @@ import com.runnect.runnect.databinding.ActivityMainBinding
 import com.runnect.runnect.presentation.coursemain.CourseMainFragment
 import com.runnect.runnect.presentation.discover.DiscoverFragment
 import com.runnect.runnect.presentation.mypage.MyPageFragment
-import com.runnect.runnect.presentation.mypage.setting.MySettingFragment
 import com.runnect.runnect.presentation.storage.StorageMainFragment
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
@@ -45,15 +44,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     fun getBtnDeleteCourseMain(): View? {
         return findViewById(R.id.btn_delete_course_main)
     }
-
-    fun moveToSettingFragment() {
-        supportFragmentManager.commit {
-            this.setCustomAnimations(R.anim.slide_in_right, R.anim.slide_out_left)
-            replace<MySettingFragment>(R.id.fl_main)
-        }
-
-    }
-
 
     private fun initView() {
         if (!isChangeToStorage && !isChangeToDiscover) {//1. 앱 처음 빌드

--- a/app/src/main/java/com/runnect/runnect/presentation/login/GoogleLogin.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/login/GoogleLogin.kt
@@ -72,6 +72,7 @@ class GoogleLogin(activity: LoginActivity, viewModel: LoginViewModel) : SocialLo
     }
 
     override fun clearSocialLogin() {
+        mGoogleSignInClient.revokeAccess()
         resultLauncher.unregister()
         activityRef.clear()
         viewModelRef.clear()

--- a/app/src/main/java/com/runnect/runnect/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/login/LoginActivity.kt
@@ -5,6 +5,7 @@ import android.content.ContentValues
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.core.view.isVisible
 import com.runnect.runnect.application.PreferenceManager
 import com.runnect.runnect.databinding.ActivityLoginBinding
 import com.runnect.runnect.presentation.MainActivity
@@ -72,9 +73,10 @@ class LoginActivity :
     }
 
     private fun addObserver() { //방문자 모드는 여기 logic에 해당이 안 돼.
-        viewModel.loginState.observe(this) {
-            if (it == UiState.Success) {
-                if (viewModel.loginResult.value?.status == 200) {
+        viewModel.loginState.observe(this) { state ->
+            when (state) {
+                UiState.Loading -> binding.indeterminateBar.isVisible = true
+                UiState.Success -> {
                     PreferenceManager.setString(
                         applicationContext,
                         "access",
@@ -86,7 +88,9 @@ class LoginActivity :
                         viewModel.loginResult.value?.refreshToken
                     )
                     moveToMain()
+                    binding.indeterminateBar.isVisible = false
                 }
+                else -> binding.indeterminateBar.isVisible = false
             }
         }
         viewModel.errorMessage.observe(this) {
@@ -105,7 +109,7 @@ class LoginActivity :
 
     override fun onDestroy() {
         super.onDestroy()
-        if(::socialLogin.isInitialized){
+        if (::socialLogin.isInitialized) {
             socialLogin.clearSocialLogin()
         }
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageFragment.kt
@@ -153,6 +153,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
                 UiState.Loading -> {
                     binding.indeterminateBar.isVisible = true
                     binding.ivMyPageEditFrame.isClickable = false
+                    binding.viewMyPageMainSettingFrame.isClickable = false
                 }
                 UiState.Success -> {
                     binding.indeterminateBar.isVisible = false
@@ -162,6 +163,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
                     )
                     viewModel.setProfileImg(stampResId)
                     binding.ivMyPageEditFrame.isClickable = true
+                    binding.viewMyPageMainSettingFrame.isClickable = true
                 }
                 UiState.Failure -> {
                     binding.indeterminateBar.isVisible = false

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageFragment.kt
@@ -9,22 +9,22 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
 import com.runnect.runnect.R
 import com.runnect.runnect.application.ApplicationClass
 import com.runnect.runnect.application.PreferenceManager
 import com.runnect.runnect.binding.BindingFragment
 import com.runnect.runnect.databinding.FragmentMyPageBinding
-import com.runnect.runnect.presentation.MainActivity
 import com.runnect.runnect.presentation.login.LoginActivity
 import com.runnect.runnect.presentation.mypage.editname.MyPageEditNameActivity
 import com.runnect.runnect.presentation.mypage.history.MyHistoryActivity
 import com.runnect.runnect.presentation.mypage.reward.MyRewardActivity
+import com.runnect.runnect.presentation.mypage.setting.MySettingFragment
 import com.runnect.runnect.presentation.mypage.upload.MyUploadActivity
 import com.runnect.runnect.presentation.state.UiState
 import com.runnect.runnect.util.extension.getStampResId
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.fragment_my_page.*
-import kotlinx.android.synthetic.main.fragment_my_page.view.*
 import timber.log.Timber
 
 
@@ -130,7 +130,15 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
             )
         }
         binding.viewMyPageMainSettingFrame.setOnClickListener {
-            (requireActivity() as MainActivity).moveToSettingFragment()
+            moveToSettingFragment()
+        }
+    }
+
+    private fun moveToSettingFragment() {
+        val bundle = Bundle().apply { putString(ACCOUNT_INFO_TAG, viewModel.email.value) }
+        requireActivity().supportFragmentManager.commit {
+            this.setCustomAnimations(R.anim.slide_in_right, R.anim.slide_out_left)
+            replace<MySettingFragment>(R.id.fl_main, args = bundle)
         }
     }
 
@@ -169,5 +177,6 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
         const val RES_STAMP_TYPE = "drawable"
         const val NICK_NAME = "nickname"
         const val PROFILE = "profile_img"
+        const val ACCOUNT_INFO_TAG = "accountInfo"
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageFragment.kt
@@ -37,13 +37,19 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        checkVisitorMode()
+//        checkVisitorMode()
+        binding.vm = viewModel
+        binding.lifecycleOwner = this.viewLifecycleOwner
+        viewModel.getUserInfo()
+        addListener()
+        addObserver()
+        setResultEditNameLauncher()
 
-        if (isVisitorMode) {
-            activateVisitorMode()
-        } else {
-            deactivateVisitorMode()
-        }
+//        if (isVisitorMode) {
+//            activateVisitorMode()
+//        } else {
+//            deactivateVisitorMode()
+//        }
 
     }
 
@@ -74,7 +80,7 @@ class MyPageFragment : BindingFragment<FragmentMyPageBinding>(R.layout.fragment_
             constraintInside.isVisible = true
 
             binding.vm = viewModel
-            binding.lifecycleOwner = this.lifecycleOwner
+            binding.lifecycleOwner = this@MyPageFragment.viewLifecycleOwner
             viewModel.getUserInfo()
             addListener()
             addObserver()

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageViewModel.kt
@@ -9,6 +9,7 @@ import com.runnect.runnect.domain.UserRepository
 import com.runnect.runnect.presentation.state.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,6 +20,7 @@ class MyPageViewModel @Inject constructor(private val userRepository: UserReposi
     val profileImg: MutableLiveData<Int> = MutableLiveData<Int>(R.drawable.user_profile_basic)
     val level: MutableLiveData<String> = MutableLiveData<String>()
     val levelPercent: MutableLiveData<Int> = MutableLiveData<Int>()
+    val email:MutableLiveData<String> = MutableLiveData<String>()
 
     private val _userInfoState = MutableLiveData<UiState>(UiState.Loading)
     val userInfoState: LiveData<UiState>
@@ -43,6 +45,7 @@ class MyPageViewModel @Inject constructor(private val userRepository: UserReposi
                 stampId.value = it.data.user.latestStamp
                 level.value = it.data.user.level.toString()
                 levelPercent.value = it.data.user.levelPercent
+                email.value = it.data.user.email
                 _userInfoState.value = UiState.Success
             }.onFailure {
                 errorMessage.value = it.message

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageViewModel.kt
@@ -41,9 +41,9 @@ class MyPageViewModel @Inject constructor(private val userRepository: UserReposi
                 _userInfoState.value = UiState.Loading
                 userRepository.getUserInfo()
             }.onSuccess {
+                level.value = it.data.user.level.toString()
                 nickName.value = it.data.user.nickname
                 stampId.value = it.data.user.latestStamp
-                level.value = it.data.user.level.toString()
                 levelPercent.value = it.data.user.levelPercent
                 email.value = it.data.user.email
                 _userInfoState.value = UiState.Success

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
@@ -1,20 +1,34 @@
 package com.runnect.runnect.presentation.mypage.setting
 
+import android.app.AlertDialog
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import androidx.fragment.app.viewModels
 import com.runnect.runnect.R
 import com.runnect.runnect.binding.BindingFragment
 import com.runnect.runnect.databinding.FragmentMySettingAccountInfoBinding
+import com.runnect.runnect.presentation.login.LoginActivity
+import com.runnect.runnect.util.extension.setCustomDialog
+import com.runnect.runnect.util.extension.setDialogClickListener
+import com.runnect.runnect.util.extension.showToast
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.android.synthetic.main.custom_dialog_delete.*
 
-
+@AndroidEntryPoint
 class MySettingAccountInfoFragment :
     BindingFragment<FragmentMySettingAccountInfoBinding>(R.layout.fragment_my_setting_account_info) {
+    private lateinit var logoutDialog: AlertDialog
+    private val viewModel: MySettingAccountInfoViewModel by viewModels()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initLayout()
         addListener()
+        initLogoutDialog()
+        setLogoutDialogClickEvent()
     }
 
     private fun initLayout() {
@@ -25,7 +39,29 @@ class MySettingAccountInfoFragment :
         binding.ivSettingAccountInfoBack.setOnClickListener {
             moveToMySetting()
         }
+
+        binding.viewSettingAccountInfoLogoutFrame.setOnClickListener {
+            logoutDialog.show()
+        }
+    }
+
+    private fun initLogoutDialog() {
+        logoutDialog = requireActivity().setCustomDialog(
+            layoutInflater, binding.root, DESC_LOGOUT,
+            DESC_LOGOUT_YES, DESC_LOGOUT_NO
+        )
+    }
+
+    private fun setLogoutDialogClickEvent() {
+        logoutDialog.setDialogClickListener { which ->
+            when (which) {
+                logoutDialog.btn_delete_yes -> {
+                    val intent = Intent(requireActivity(),LoginActivity::class.java)
                     intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NO_HISTORY
+                    startActivity(intent)
+                }
+            }
+        }
     }
 
     private fun moveToMySetting() {
@@ -43,5 +79,8 @@ class MySettingAccountInfoFragment :
 
     companion object {
         const val ACCOUNT_INFO_TAG = "accountInfo"
+        const val DESC_LOGOUT = "로그아웃 하시겠어요?"
+        const val DESC_LOGOUT_YES = "네"
+        const val DESC_LOGOUT_NO = "아니오"
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
@@ -25,6 +25,7 @@ class MySettingAccountInfoFragment :
         binding.ivSettingAccountInfoBack.setOnClickListener {
             moveToMySetting()
         }
+                    intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NO_HISTORY
     }
 
     private fun moveToMySetting() {

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
@@ -61,7 +61,7 @@ class MySettingAccountInfoFragment :
                     PreferenceManager.setString(requireContext(), "refresh","none")
                     val intent = Intent(requireActivity(),LoginActivity::class.java)
                     intent.putExtra("isLogout",true)
-                    intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NO_HISTORY
+                    intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
                     startActivity(intent)
                 }
             }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import androidx.fragment.app.viewModels
 import com.runnect.runnect.R
+import com.runnect.runnect.application.PreferenceManager
 import com.runnect.runnect.binding.BindingFragment
 import com.runnect.runnect.databinding.FragmentMySettingAccountInfoBinding
 import com.runnect.runnect.presentation.login.LoginActivity
@@ -56,7 +57,10 @@ class MySettingAccountInfoFragment :
         logoutDialog.setDialogClickListener { which ->
             when (which) {
                 logoutDialog.btn_delete_yes -> {
+                    PreferenceManager.setString(requireContext(), "access","none")
+                    PreferenceManager.setString(requireContext(), "refresh","none")
                     val intent = Intent(requireActivity(),LoginActivity::class.java)
+                    intent.putExtra("isLogout",true)
                     intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NO_HISTORY
                     startActivity(intent)
                 }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoFragment.kt
@@ -1,0 +1,46 @@
+package com.runnect.runnect.presentation.mypage.setting
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
+import com.runnect.runnect.R
+import com.runnect.runnect.binding.BindingFragment
+import com.runnect.runnect.databinding.FragmentMySettingAccountInfoBinding
+
+
+class MySettingAccountInfoFragment :
+    BindingFragment<FragmentMySettingAccountInfoBinding>(R.layout.fragment_my_setting_account_info) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initLayout()
+        addListener()
+    }
+
+    private fun initLayout() {
+        setEmailFromMySetting()
+    }
+
+    private fun addListener() {
+        binding.ivSettingAccountInfoBack.setOnClickListener {
+            moveToMySetting()
+        }
+    }
+
+    private fun moveToMySetting() {
+        val fragmentManager = requireActivity().supportFragmentManager
+        fragmentManager.commit {
+            this.setCustomAnimations(R.anim.slide_in_left, R.anim.slide_out_right)
+            replace<MySettingFragment>(R.id.fl_main)
+        }
+    }
+
+    private fun setEmailFromMySetting() {
+        val bundle = arguments
+        binding.tvSettingAccountInfoIdEmail.text = bundle?.getString(ACCOUNT_INFO_TAG)
+    }
+
+    companion object {
+        const val ACCOUNT_INFO_TAG = "accountInfo"
+    }
+}

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoViewModel.kt
@@ -1,11 +1,34 @@
 package com.runnect.runnect.presentation.mypage.setting
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.runnect.runnect.domain.UserRepository
+import com.runnect.runnect.presentation.state.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MySettingAccountInfoViewModel @Inject constructor(private val userRepository: UserRepository) :
     ViewModel() {
+    private val _withdrawalState = MutableLiveData<UiState>()
+    val withdrawalState: LiveData<UiState>
+        get() = _withdrawalState
+    val errorMessage = MutableLiveData<String>()
+
+    fun deleteUser() {
+        viewModelScope.launch {
+            runCatching {
+                _withdrawalState.value = UiState.Loading
+                userRepository.deleteUser()
+            }.onSuccess {
+                _withdrawalState.value = UiState.Success
+            }.onFailure {
+                errorMessage.value = it.message
+                _withdrawalState.value = UiState.Failure
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingAccountInfoViewModel.kt
@@ -1,0 +1,11 @@
+package com.runnect.runnect.presentation.mypage.setting
+
+import androidx.lifecycle.ViewModel
+import com.runnect.runnect.domain.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class MySettingAccountInfoViewModel @Inject constructor(private val userRepository: UserRepository) :
+    ViewModel() {
+}

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingFragment.kt
@@ -18,11 +18,36 @@ class MySettingFragment : BindingFragment<FragmentMySettingBinding>(R.layout.fra
 
     private fun addListener() {
         binding.ivSettingBack.setOnClickListener {
-            val fragmentManager = requireActivity().supportFragmentManager
-            fragmentManager.commit {
-                this.setCustomAnimations(R.anim.slide_in_left, R.anim.slide_out_right)
-                replace<MyPageFragment>(R.id.fl_main)
-            }
+            moveToMyPage()
         }
+        binding.viewSettingAccountInfoFrame.setOnClickListener {
+            moveToMySettingAccountInfo()
+        }
+    }
+
+    private fun moveToMyPage() {
+        val fragmentManager = requireActivity().supportFragmentManager
+        fragmentManager.commit {
+            this.setCustomAnimations(R.anim.slide_in_left, R.anim.slide_out_right)
+            replace<MyPageFragment>(R.id.fl_main)
+        }
+    }
+
+    private fun moveToMySettingAccountInfo() {
+        val emailFromMyPage = getEmailFromMyPage()
+        val bundle = Bundle().apply { putString(ACCOUNT_INFO_TAG, emailFromMyPage) }
+        val fragmentManager = requireActivity().supportFragmentManager
+        fragmentManager.commit {
+            this.setCustomAnimations(R.anim.slide_in_right, R.anim.slide_out_left)
+            replace<MySettingAccountInfoFragment>(R.id.fl_main, args = bundle)
+        }
+    }
+    private fun getEmailFromMyPage(): String? {
+        val bundleFromMyPage = arguments
+        return bundleFromMyPage?.getString(ACCOUNT_INFO_TAG)
+    }
+
+    companion object {
+        const val ACCOUNT_INFO_TAG = "accountInfo"
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/splash/SplashActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/splash/SplashActivity.kt
@@ -21,6 +21,7 @@ class SplashActivity : AppCompatActivity() {
         handler.postDelayed({
             val intent = Intent(this, LoginActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+            intent.flags = Intent.FLAG_ACTIVITY_NO_HISTORY
             startActivity(intent)
             finish()
         }, (1000 * sec).toLong())

--- a/app/src/main/java/com/runnect/runnect/presentation/splash/SplashActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/splash/SplashActivity.kt
@@ -21,7 +21,6 @@ class SplashActivity : AppCompatActivity() {
         handler.postDelayed({
             val intent = Intent(this, LoginActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
-            intent.flags = Intent.FLAG_ACTIVITY_NO_HISTORY
             startActivity(intent)
             finish()
         }, (1000 * sec).toLong())

--- a/app/src/main/java/com/runnect/runnect/util/extension/ContextExt.kt
+++ b/app/src/main/java/com/runnect/runnect/util/extension/ContextExt.kt
@@ -109,9 +109,16 @@ fun BottomSheetDialog.setEditBottomSheetClickListener(listener:(which:LinearLayo
 
 fun Context.getStampResId(stampId: String?,resNameParam:String,resType:String,packageName:String):Int{
     with(this) {
-        val resName = "${resNameParam}$stampId"
-        return resources.getIdentifier(resName,
-            resType, packageName)
-
+        var resName = ""
+        if(stampId == "CSPR0"){
+            resName = "${resNameParam}basic"
+            return resources.getIdentifier(resName,
+                resType, packageName)
+        }
+        else{
+            resName = "${resNameParam}$stampId"
+            return resources.getIdentifier(resName,
+                resType, packageName)
+        }
     }
 }

--- a/app/src/main/res/drawable/mypage_img_stamp_basic.xml
+++ b/app/src/main/res/drawable/mypage_img_stamp_basic.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="96dp"
+    android:height="96dp"
+    android:viewportWidth="96"
+    android:viewportHeight="96">
+    <path
+        android:pathData="M48,48m-48,0a48,48 0,1 1,96 0a48,48 0,1 1,-96 0"
+        android:fillColor="#D5D4FF"/>
+    <path
+        android:pathData="M48.5,41.5m-17.5,0a17.5,17.5 0,1 1,35 0a17.5,17.5 0,1 1,-35 0"
+        android:fillColor="#ffffff"/>
+    <path
+        android:pathData="M48,66C27.2,66 19.333,78.667 18,85C22.167,88.667 34,96 48,96C62,96 73.833,88.667 78,85C76.667,78.667 68.8,66 48,66Z"
+        android:fillColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -11,7 +11,18 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".presentation.login.LoginActivity">
-
+        <ProgressBar
+            android:id="@+id/indeterminateBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:elevation="2dp"
+            android:indeterminateTint="@color/G3"
+            android:outlineProvider="none"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
         <ImageView
             android:id="@+id/iv_login_background"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_my_setting_account_info.xml
+++ b/app/src/main/res/layout/fragment_my_setting_account_info.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar_setting_account_info"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:contentInsetStart="0dp"
+            app:layout_constraintDimensionRatio="360:48"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/iv_setting_account_info_back"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:padding="10dp"
+                app:srcCompat="@drawable/all_back_arrow" />
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tv_setting_account_info_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/start_margin_toolbar"
+                android:fontFamily="@font/pretendard_bold"
+                android:text="@string/my_setting_account_info"
+                android:textColor="@color/G1"
+                android:textSize="18sp" />
+        </androidx.appcompat.widget.Toolbar>
+
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/divider_setting_account_info_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="4dp"
+            android:background="@color/G5"
+            app:layout_constraintTop_toBottomOf="@+id/toolbar_setting_account_info" />
+
+        <View
+            android:id="@+id/view_setting_account_info_id_frame"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@drawable/my_page_under_stroke"
+            app:layout_constraintDimensionRatio="360:60"
+            app:layout_constraintTop_toBottomOf="@id/divider_setting_account_info_toolbar" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_setting_account_info_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:fontFamily="@font/pretendard_medium"
+            android:text="@string/account_info_id"
+            android:textColor="@color/G1"
+            android:textSize="15sp"
+            app:layout_constraintBottom_toBottomOf="@id/view_setting_account_info_id_frame"
+            app:layout_constraintStart_toStartOf="@id/view_setting_account_info_id_frame"
+            app:layout_constraintTop_toTopOf="@id/view_setting_account_info_id_frame" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_setting_account_info_id_email"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="15dp"
+            android:fontFamily="@font/pretendard_regular"
+            android:lineHeight="22dp"
+            android:textColor="@color/G2"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toBottomOf="@id/view_setting_account_info_id_frame"
+            app:layout_constraintEnd_toEndOf="@id/view_setting_account_info_id_frame"
+            app:layout_constraintTop_toTopOf="@id/view_setting_account_info_id_frame"
+            tools:text="yosan7939@gmail.com" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="8dp"
+            android:background="@color/G5"
+            app:layout_constraintTop_toBottomOf="@id/view_setting_account_info_id_frame" />
+
+        <View
+            android:id="@+id/view_setting_account_info_logout_frame"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@drawable/my_page_under_stroke"
+            app:layout_constraintDimensionRatio="360:60"
+            app:layout_constraintTop_toBottomOf="@id/view_setting_account_info_id_frame" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_setting_account_info_logout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:fontFamily="@font/pretendard_medium"
+            android:text="@string/account_info_logout"
+            android:textColor="@color/G1"
+            android:textSize="15sp"
+            app:layout_constraintBottom_toBottomOf="@id/view_setting_account_info_logout_frame"
+            app:layout_constraintStart_toStartOf="@id/view_setting_account_info_logout_frame"
+            app:layout_constraintTop_toTopOf="@id/view_setting_account_info_logout_frame" />
+
+        <View
+            android:id="@+id/view_setting_account_info_withdrawal_frame"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@drawable/my_page_under_stroke"
+            app:layout_constraintDimensionRatio="360:60"
+            app:layout_constraintTop_toBottomOf="@id/view_setting_account_info_logout_frame" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/tv_setting_account_info_withdrawal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:fontFamily="@font/pretendard_medium"
+            android:text="@string/account_info_withdrawal"
+            android:textColor="@color/G1"
+            android:textSize="15sp"
+            app:layout_constraintBottom_toBottomOf="@id/view_setting_account_info_withdrawal_frame"
+            app:layout_constraintStart_toStartOf="@id/view_setting_account_info_withdrawal_frame"
+            app:layout_constraintTop_toTopOf="@id/view_setting_account_info_withdrawal_frame" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_my_setting_account_info.xml
+++ b/app/src/main/res/layout/fragment_my_setting_account_info.xml
@@ -10,6 +10,18 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+        <ProgressBar
+            android:id="@+id/indeterminateBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:elevation="2dp"
+            android:indeterminateTint="@color/G3"
+            android:outlineProvider="none"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
 
         <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,4 +106,7 @@
     <string name="my_setting_account_info">계정 정보</string>
     <string name="my_setting_report">문의 및 신고하기</string>
     <string name="my_setting_terms">이용약관</string>
+    <string name="account_info_id">아이디</string>
+    <string name="account_info_logout">로그아웃</string>
+    <string name="account_info_withdrawal">회원탈퇴</string>
 </resources>


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#105 마이페이지 설정 계정 정보 뷰 작업
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
레이아웃 작성
화면 전환 및 데이터 전달 구현
아이디 데이터 받아와서 표시
마이페이지 로딩이 끝나고 나서 전환 가능하도록 구현
로그아웃 구현(카카오, 구글)
 - 다이얼로그 구현
 - 로그아웃 기능 구현
 
탈퇴하기 구현

## 📸 스크린샷(선택)
<!-- 추가 설명이 필요한 경우 스크린샷을 첨부해주세요 -->
https://github.com/Runnect/Runnect-Android/assets/70442964/c355e455-f9d1-48c8-baf7-c262a467223e

