### PR TITLE
Fix/107 Response 관련 이슈 해결

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/dto/CourseDetailDTO.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/CourseDetailDTO.kt
@@ -1,7 +1,7 @@
 package com.runnect.runnect.data.dto
 
 data class CourseDetailDTO(
-    val stampId: Int,
+    val stampId: String,
     val level: String,
     val nickname: String,
     val courseId: Int,

--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseCourseDetail.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseCourseDetail.kt
@@ -60,7 +60,7 @@ data class DetailPublicCourse(
 @Serializable
 data class DetailDeparture(
     val city: String,
-    val name: String,
+    val name: String?,
     val region: String,
     val town: String
 )

--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseCourseDetail.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseCourseDetail.kt
@@ -30,7 +30,7 @@ data class CourseDetailUser(
     @SerializedName("isNowUser")
     val isNowUser: Boolean,
     @SerializedName("level")
-    val level: Int,
+    val level: String,
     @SerializedName("nickname")
     val nickname: String
 )

--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseUpdateNickName.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseUpdateNickName.kt
@@ -1,26 +1,38 @@
 package com.runnect.runnect.data.dto.response
 
+import com.google.gson.annotations.SerializedName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ResponseUpdateNickName(
-    val `data`: Data,
+    @SerializedName("data")
+    val `data`: UpdateData,
+    @SerializedName("message")
     val message: String,
+    @SerializedName("status")
     val status: Int,
+    @SerializedName("success")
     val success: Boolean
 )
 
 @Serializable
 data class UpdateUser(
+    @SerializedName("latestStamp")
     val latestStamp: String,
+    @SerializedName("level")
     val level: Int,
+    @SerializedName("levelPercent")
     val levelPercent: Int,
-    val machineId: String,
+    @SerializedName("id")
+    val id: Int,
+    @SerializedName("modifiedAt")
     val modifiedAt: String,
+    @SerializedName("nickname")
     val nickname: String
 )
 
 @Serializable
 data class UpdateData(
-    val user: User
+    @SerializedName("user")
+    val user: UpdateUser
 )

--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
@@ -275,6 +275,7 @@ class CourseDetailActivity :
         viewModel.editContent.value = viewModel.contentForInterruption.value
         viewModel.isEdited = true
         enterReadMode()
+        showToast("수정이 완료되었습니다")
     }
 
     private fun initEditBottomSheet() {

--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
@@ -211,8 +211,11 @@ class CourseDetailActivity :
             if (state == UiState.Success) {
                 with(binding) {
                     with(viewModel.courseDetail) {
-                        ivCourseDetailMap.load(image)
-                        ivCourseDetailProfileStamp.load(stampId)
+                        val stampResId = this@CourseDetailActivity.getStampResId(
+                            viewModel.stampId.value,
+                            RES_NAME, RES_STAMP_TYPE, packageName
+                        )
+                        ivCourseDetailProfileStamp.load(stampResId)
                         ivCourseDetailProfileNickname.text = nickname
                         tvCourseDetailProfileLv.text = level
                         ivCourseDetailScrap.isSelected = scrap
@@ -366,5 +369,7 @@ class CourseDetailActivity :
         const val EDIT_INTERRUPT_DIALOG_YES_BTN = "예"
         const val EDIT_INTERRUPT_DIALOG_NO_BTN = "아니오"
         const val MY_UPLOAD_ACTIVITY_TAG = "upload"
+        const val RES_NAME = "mypage_img_stamp_"
+        const val RES_STAMP_TYPE = "drawable"
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
@@ -217,8 +217,15 @@ class CourseDetailActivity :
                         )
                         ivCourseDetailProfileStamp.load(stampResId)
                         ivCourseDetailProfileNickname.text = nickname
-                        tvCourseDetailProfileLv.text = level
+                        if(level=="알 수 없음"){
+                            tvCourseDetailProfileLv.isVisible = false
+                            tvCourseDetailProfileLvIndicator.isVisible = false
+                        }
+                        else{
+                            tvCourseDetailProfileLv.text = level
+                        }
                         ivCourseDetailScrap.isSelected = scrap
+
                     }
 
                 }

--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailViewModel.kt
@@ -34,6 +34,7 @@ class CourseDetailViewModel @Inject constructor(
 
     private lateinit var courseToDelete: List<Int>
 
+    var stampId: MutableLiveData<String> = MutableLiveData("CSPR0")
     var mapImage: MutableLiveData<String> = MutableLiveData(DEFAULT_MAP_IMAGE)
     var editTitle: MutableLiveData<String> = MutableLiveData("")
     var editContent: MutableLiveData<String> = MutableLiveData("")
@@ -62,7 +63,7 @@ class CourseDetailViewModel @Inject constructor(
         get() = _editMode
 
     private var _courseDetail = CourseDetailDTO(
-        R.drawable.user_profile_basic,
+        "CSPR0",
         "1",
         "1",
         1,
@@ -92,6 +93,7 @@ class CourseDetailViewModel @Inject constructor(
                 courseRepository.getCourseDetail(courseId)
             }.onSuccess {
                 _courseDetail = it
+                stampId.value = it.stampId
                 mapImage.value = it.image
                 editTitle.value = it.title
                 editContent.value = it.description

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/search/DiscoverSearchActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/search/DiscoverSearchActivity.kt
@@ -27,7 +27,7 @@ import timber.log.Timber
 
 @AndroidEntryPoint
 class DiscoverSearchActivity :
-    BindingActivity<ActivityDiscoverSearchBinding>(com.runnect.runnect.R.layout.activity_discover_search),
+    BindingActivity<ActivityDiscoverSearchBinding>(R.layout.activity_discover_search),
     OnItemClick, OnHeartClick {
     private val viewModel: DiscoverSearchViewModel by viewModels()
     private lateinit var adapter: DiscoverSearchAdapter
@@ -81,28 +81,33 @@ class DiscoverSearchActivity :
         viewModel.courseSearchState.observe(this) {
             Timber.d("${viewModel.courseSearchList.isEmpty()}")
             when (it) {
-                UiState.Empty -> binding.indeterminateBar.isVisible = false //visible 옵션으로 처리하는 게 맞나
+                UiState.Empty -> {
+                    handleUnsuccessfulCourseSearch()
+                }
                 UiState.Loading -> binding.indeterminateBar.isVisible = true
                 UiState.Success -> {
                     binding.indeterminateBar.isVisible = false
-                    //검색 결과가 존재할 때
                     binding.svDiscoverSearch.isVisible = true
                     binding.constDiscoverSearchNoResult.isVisible = false
-                    //어댑터에 받아온 코스정보 리스트를 전달하는 submitList 작업
                     initAdapter()
                 }
                 UiState.Failure -> {
-                    binding.indeterminateBar.isVisible = false
+                    handleUnsuccessfulCourseSearch()
                     Timber.tag(ContentValues.TAG)
                         .d("Failure : ${viewModel.errorMessage.value}")
-                    //검색결과가 존재하지 않을 때
-                    binding.svDiscoverSearch.isVisible = false
-                    binding.constDiscoverSearchNoResult.isVisible = true
                 }
 
             }
         }
 
+    }
+
+    private fun handleUnsuccessfulCourseSearch(){
+        with(binding){
+            indeterminateBar.isVisible = false
+            svDiscoverSearch.isVisible = false
+            constDiscoverSearchNoResult.isVisible = true
+        }
     }
 
 

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/search/DiscoverSearchViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/search/DiscoverSearchViewModel.kt
@@ -31,9 +31,13 @@ class DiscoverSearchViewModel @Inject constructor(private val courseRepository: 
             runCatching {
                 courseRepository.getCourseSearch(keyword)
             }.onSuccess {
-                Timber.d("검색 성공")
                 courseSearchList = it
-                _courseSearchState.value = UiState.Success
+                if(courseSearchList.isEmpty()){
+                    _courseSearchState.value = UiState.Empty
+                }
+                else{
+                    _courseSearchState.value = UiState.Success
+                }
             }.onFailure {
                 Timber.d("검색 실패 ${it.message} ${it.cause}")
                 errorMessage.value = it.message

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/history/detail/MyHistoryDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/history/detail/MyHistoryDetailActivity.kt
@@ -130,6 +130,7 @@ class MyHistoryDetailActivity :
                     binding.indeterminateBar.isVisible = false
                     enterReadMode()
                     viewModel.titleForInterruption = viewModel.title.value.toString()
+                    showToast("수정이 완료되었습니다")
                 }
                 UiState.Failure -> {
                     binding.indeterminateBar.isVisible = false

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadActivity.kt
@@ -12,6 +12,7 @@ import com.runnect.runnect.R
 import com.runnect.runnect.binding.BindingActivity
 import com.runnect.runnect.databinding.ActivityMyUploadBinding
 import com.runnect.runnect.presentation.detail.CourseDetailActivity
+import com.runnect.runnect.presentation.discover.load.DiscoverLoadActivity
 import com.runnect.runnect.presentation.mypage.upload.adapter.MyUploadAdapter
 import com.runnect.runnect.presentation.state.UiState
 import com.runnect.runnect.util.GridSpacingItemDecoration
@@ -23,7 +24,8 @@ import kotlinx.android.synthetic.main.custom_dialog_delete.*
 import timber.log.Timber
 
 @AndroidEntryPoint
-class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activity_my_upload), OnUploadItemClick {
+class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activity_my_upload),
+    OnUploadItemClick {
     private val viewModel: MyUploadViewModel by viewModels()
     private lateinit var adapter: MyUploadAdapter
     private lateinit var dialog: AlertDialog
@@ -55,23 +57,36 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
         binding.tvMyPageUploadDelete.setOnClickListener {
             handleDeleteButtonClicked(it)
         }
+        binding.cvUploadMyPageUploadCourse.setOnClickListener {
+            startActivity(Intent(this, DiscoverLoadActivity::class.java))
+            finish()
+            overridePendingTransition(
+                R.anim.slide_in_right,
+                R.anim.slide_out_left
+            )
+        }
     }
-    private fun handleEditClicked(){
+
+    private fun handleEditClicked() {
         viewModel.convertMode()
         binding.tvMyPageUploadDelete.isVisible = viewModel.editMode.value!!
     }
-    private fun handleDeleteButtonClicked(it: View){
+
+    private fun handleDeleteButtonClicked(it: View) {
         if (it.isActivated) {
             setDialogClickEvent()
             dialog.show()
         }
     }
+
     private fun initDialog() {
-        dialog = setCustomDialog(layoutInflater, binding.root,
+        dialog = setCustomDialog(
+            layoutInflater, binding.root,
             DIALOG_DESC,
             DELETE_BTN
         )
     }
+
     private fun setDialogClickEvent() {
         dialog.setDialogClickListener { which ->
             when (which) {
@@ -87,7 +102,7 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
     }
 
     private fun initAdapter() {
-        adapter = MyUploadAdapter(this,this).apply {
+        adapter = MyUploadAdapter(this, this).apply {
             submitList(
                 viewModel.myUploadCourses
             )
@@ -117,7 +132,7 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
             }
         }
 
-        viewModel.editMode.observe(this){editMode ->
+        viewModel.editMode.observe(this) { editMode ->
             if (editMode) {
                 enterEditMode()
             } else {
@@ -131,6 +146,7 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
 
         viewModel.selectCountMediator.observe(this) {}
     }
+
     private fun enterEditMode() {
         with(binding) {
             btnMyPageUploadEditCourse.text = EDIT_CANCEL
@@ -168,8 +184,8 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
         }
     }
 
-    private fun handleSuccessfulCourseLoad(){
-        with(binding){
+    private fun handleSuccessfulCourseLoad() {
+        with(binding) {
             indeterminateBar.isVisible = false
             tvMyPageUploadTotalCourseCount.text = viewModel.getCourseCount()
             constMyPageUploadEditBar.isVisible = true
@@ -184,30 +200,33 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
         adapter.clearSelection()
         viewModel.clearItemsToDelete()
     }
+
     private fun handleUnsuccessfulUploadCall() {
         binding.indeterminateBar.isVisible = false
         Timber.tag(ContentValues.TAG).d("Failure : ${viewModel.errorMessage.value}")
     }
 
-    private fun handleEmptyUploadCourse(){
+    private fun handleEmptyUploadCourse() {
         with(binding) {
             indeterminateBar.isVisible = false
             constMyPageUploadEditBar.isVisible = false
             layoutMyPageUploadNoResult.isVisible = true
         }
     }
+
     override fun selectItem(id: Int): Boolean {
         return if (viewModel.editMode.value == true) {
             viewModel.modifyItemsToDelete(id)
             true
         } else {
-            val intent = Intent(this,CourseDetailActivity::class.java)
-            intent.putExtra("courseId",id)
-            intent.putExtra("root","upload")
+            val intent = Intent(this, CourseDetailActivity::class.java)
+            intent.putExtra("courseId", id)
+            intent.putExtra("root", "upload")
             startActivity(intent)
             false
         }
     }
+
     companion object {
         const val CHOICE_MODE_DESC = "기록 선택"
         const val EDIT_CANCEL = "취소"

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadViewModel.kt
@@ -59,7 +59,11 @@ class MyUploadViewModel @Inject constructor(private val userRepository: UserRepo
                 userRepository.getUserUploadCourse()
             }.onSuccess {
                 _myUploadCourses = it
-                _myUploadCourseState.value = UiState.Success
+                if (_myUploadCourses.isEmpty()) {
+                    _myUploadCourseState.value = UiState.Empty
+                } else {
+                    _myUploadCourseState.value = UiState.Success
+                }
             }.onFailure {
                 errorMessage.value = it.message
                 _myUploadCourseState.value = UiState.Failure
@@ -77,7 +81,7 @@ class MyUploadViewModel @Inject constructor(private val userRepository: UserRepo
                 _myUploadCourses =
                     _myUploadCourses.filter { !itemsToDelete.contains(it.id) }.toMutableList()
                 _myUploadDeleteState.value = UiState.Success
-                //모든 기록 삭제 시, 편집 모드 취소
+                //모든 기록 삭제 시, 편집 모드 -> 읽기 모드
                 if (_myUploadCourses.isEmpty()) {
                     _myUploadCourseState.value = UiState.Empty
                     convertMode()
@@ -106,11 +110,13 @@ class MyUploadViewModel @Inject constructor(private val userRepository: UserRepo
         }
         itemsToDeleteLiveData.value = _itemsToDelete
     }
+
     fun clearItemsToDelete() {
         _itemsToDelete.clear()
         itemsToDeleteLiveData.value = _itemsToDelete
     }
-    companion object{
+
+    companion object {
         const val DEFAULT_SELECTED_COUNT = 0
     }
 }

--- a/app/src/main/java/com/runnect/runnect/util/extension/ContextExt.kt
+++ b/app/src/main/java/com/runnect/runnect/util/extension/ContextExt.kt
@@ -109,7 +109,7 @@ fun BottomSheetDialog.setEditBottomSheetClickListener(listener:(which:LinearLayo
 
 fun Context.getStampResId(stampId: String?,resNameParam:String,resType:String,packageName:String):Int{
     with(this) {
-        var resName = ""
+        lateinit var resName:String
         if(stampId == "CSPR0"){
             resName = "${resNameParam}basic"
             return resources.getIdentifier(resName,

--- a/app/src/main/java/com/runnect/runnect/util/extension/ResponseExt.kt
+++ b/app/src/main/java/com/runnect/runnect/util/extension/ResponseExt.kt
@@ -30,7 +30,7 @@ fun RecommendPublicCourse.toData(): RecommendCourseDTO {
         id = id,
         title = title,
         scrap = scrap,
-        image = image
+        image = image,
     )
 }
 
@@ -48,7 +48,7 @@ fun SearchPublicCourse.toData(): CourseSearchDTO {
 fun DetailData.toData(): CourseDetailDTO {
     return CourseDetailDTO(
         stampId = user.image,
-        level = user.level.toString(),
+        level = user.level,
         nickname = user.nickname,
         courseId = publicCourse.courseId,
         departure = publicCourse.departure.region + ' ' + publicCourse.departure.city + ' ' + publicCourse.departure.town + ' ' + ((publicCourse.departure.name)

--- a/app/src/main/java/com/runnect/runnect/util/extension/ResponseExt.kt
+++ b/app/src/main/java/com/runnect/runnect/util/extension/ResponseExt.kt
@@ -47,7 +47,7 @@ fun SearchPublicCourse.toData(): CourseSearchDTO {
 
 fun DetailData.toData(): CourseDetailDTO {
     return CourseDetailDTO(
-        stampId = getProfileStamp(user.image),
+        stampId = user.image,
         level = user.level.toString(),
         nickname = user.nickname,
         courseId = publicCourse.courseId,
@@ -105,23 +105,5 @@ private fun paceConvert(p: String): String {
         "${pace[0]}’${pace[1]}”"
     } else {
         "${pace[0]}’${pace[1]}”${pace[2]}”"
-    }
-}
-
-private fun getProfileStamp(stamp: String): Int {
-    return when (stamp) {
-        "c1" -> R.drawable.mypage_img_stamp_c1
-        "c2" -> R.drawable.mypage_img_stamp_c2
-        "c3" -> R.drawable.mypage_img_stamp_c3
-        "s1" -> R.drawable.mypage_img_stamp_s1
-        "s2" -> R.drawable.mypage_img_stamp_s2
-        "s3" -> R.drawable.mypage_img_stamp_s3
-        "u1" -> R.drawable.mypage_img_stamp_u1
-        "u2" -> R.drawable.mypage_img_stamp_u2
-        "u3" -> R.drawable.mypage_img_stamp_u3
-        "r1" -> R.drawable.mypage_img_stamp_r1
-        "r2" -> R.drawable.mypage_img_stamp_r2
-        "r3" -> R.drawable.mypage_img_stamp_r3
-        else -> R.drawable.user_profile_basic
     }
 }

--- a/app/src/main/java/com/runnect/runnect/util/extension/ResponseExt.kt
+++ b/app/src/main/java/com/runnect/runnect/util/extension/ResponseExt.kt
@@ -67,7 +67,8 @@ fun PrivateCourse.toData(): CourseLoadInfoDTO {
     return CourseLoadInfoDTO(
         id = id,
         img = image,
-        departure = departure.region + ' ' + departure.city + ' ' + departure.town + ' ' + (departure.name?:""),
+        departure = departure.region + ' ' + departure.city + ' ' + departure.town + ' ' + (departure.name
+            ?: ""),
         distance = distance.toString()
     )
 }

--- a/app/src/main/res/layout/activity_course_detail.xml
+++ b/app/src/main/res/layout/activity_course_detail.xml
@@ -85,7 +85,7 @@
                     android:layout_width="34dp"
                     android:layout_height="0dp"
                     android:layout_marginStart="15dp"
-                    android:layout_marginTop="22dp"
+                    android:layout_marginTop="10dp"
                     android:background="@drawable/course_detail_profile_circle_frame"
                     android:padding="1dp"
                     app:layout_constraintDimensionRatio="1:1"
@@ -121,7 +121,7 @@
                     android:id="@+id/tv_course_detail_profile_lv"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="32dp"
+                    android:layout_marginTop="20dp"
                     android:layout_marginEnd="15dp"
                     android:fontFamily="@font/pretendard_semibold"
                     android:textColor="@color/M1"
@@ -130,12 +130,23 @@
                     app:layout_constraintTop_toBottomOf="@id/iv_course_detail_map"
                     tools:text="3" />
 
+                <com.google.android.material.divider.MaterialDivider
+                    android:id="@+id/divider_course_detail_profile"
+                    android:layout_width="0dp"
+                    android:background="@color/G3"
+                    android:layout_height="0.7dp"
+                    android:layout_marginHorizontal="16dp"
+                    app:layout_constraintTop_toBottomOf="@id/iv_course_detail_map"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:layout_marginTop="54dp"/>
+
                 <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/tv_course_detail_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="15dp"
-                    android:layout_marginTop="78dp"
+                    android:layout_marginTop="68dp"
                     android:fontFamily="@font/pretendard_bold"
                     android:textColor="@color/G1"
                     android:textSize="18sp"
@@ -236,7 +247,7 @@
                     android:id="@+id/view_course_detail_line"
                     android:layout_width="match_parent"
                     android:layout_height="8dp"
-                    android:layout_marginTop="185dp"
+                    android:layout_marginTop="167dp"
                     android:background="@color/G5"
                     app:layout_constraintTop_toBottomOf="@id/iv_course_detail_map" />
 


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#107 Response 관련 이슈 해결
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 출발지의 name이 null인 경우를 고려하여 Nullable로 수정
 - 탈퇴한 회원의 경우 level이 Int가 아닌 "알 수 없음"이 와서 데이터가 올바르게 전달되지 않는 문제 해결 
    -> level의 자료형을 문자열로 통일
 - 업로드 및 활동기록 수정 완료 시 토스트 메시지 띄우기
- 닉네임 수정 Response 수정
- 업로드한 코스가 없을 때 반환형이 바뀌어버리는 이슈해결
- 코스발견-검색 시, 결과가 없는 경우 로직 수정
- Ui 수정
- 업로드한 코스가 없을 시, 업로드 하기로 이동하는 로직 추가
## 📸 스크린샷(선택)
<!-- 추가 설명이 필요한 경우 스크린샷을 첨부해주세요 -->
