### PR TITLE
#136 [fix] 거리/이동시간/평균페이스 표기하는 UI 간격 통일

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/coursemain/CourseMainFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/coursemain/CourseMainFragment.kt
@@ -119,7 +119,7 @@ class CourseMainFragment :
                 }
             })
             .setRationaleTitle("위치권한 요청")
-            .setRationaleMessage("코스의 출발지 설정과 러닝 트래킹을 위해 현재 위치 정보를 사용하도록 허용합니다.")
+            .setRationaleMessage("코스의 출발지 설정과 러닝 트래킹을 위해\n현재 위치 정보를 사용하도록 허용합니다.")
             .setDeniedMessage("권한을 허용해주세요. [설정] > [앱 및 알림] > [고급] > [앱 권한]")
             .setPermissions(
                 Manifest.permission.ACCESS_COARSE_LOCATION,

--- a/app/src/main/java/com/runnect/runnect/presentation/draw/DrawActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/draw/DrawActivity.kt
@@ -88,7 +88,7 @@ class DrawActivity :
                 Timber.tag(ContentValues.TAG).d("searchResult : $searchResult")
                 viewModel.searchResult.value = searchResult
                 initView()
-                courseFinish() //여기야
+                courseFinish()
                 addObserver()
                 backButton()
                 activateDrawCourse()
@@ -141,7 +141,7 @@ class DrawActivity :
                 Handler(Looper.getMainLooper()).postDelayed(
                     {
                         viewModel.uploadCourse()
-                    }, 400
+                    }, 300
                 )
             }
         }

--- a/app/src/main/res/layout/activity_draw.xml
+++ b/app/src/main/res/layout/activity_draw.xml
@@ -47,7 +47,6 @@
             android:id="@+id/tv_draw_guide"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="7dp"
             android:elevation="3dp"
             android:fontFamily="@font/pretendard_medium"
             android:outlineProvider="none"

--- a/app/src/main/res/layout/activity_end_run.xml
+++ b/app/src/main/res/layout/activity_end_run.xml
@@ -168,20 +168,32 @@
 
         <!--총 거리-->
 
+        <View
+            android:id="@+id/view_1"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/transparent_00"
+            app:layout_constraintBottom_toTopOf="@id/btn_endRun_save"
+            app:layout_constraintEnd_toStartOf="@id/view_2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider_endRun" />
 
         <TextView
             android:id="@+id/tv_total_distance"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="30dp"
             android:fontFamily="@font/pretendard_medium"
             android:text="@string/end_run_distance_title"
             android:textColor="@color/G2"
             android:textSize="13sp"
-            app:layout_constraintEnd_toEndOf="@id/divider_vertical_rightOfDistance"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_time" />
+            app:layout_constraintBottom_toTopOf="@id/tv_distance_data"
+            app:layout_constraintEnd_toEndOf="@id/view_1"
+            app:layout_constraintStart_toStartOf="@id/view_1"
+            app:layout_constraintTop_toTopOf="@id/view_1" />
 
         <TextView
+            android:layout_marginTop="7dp"
             android:id="@+id/tv_distance_data"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -190,10 +202,10 @@
             android:text="@{model.distanceSum.toString()}"
             android:textColor="@color/G1"
             android:textSize="20sp"
-            app:layout_constraintBottom_toBottomOf="@id/tv_time_data"
             app:layout_constraintEnd_toStartOf="@id/tv_distance_unit"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="@id/tv_total_distance"
+            app:layout_constraintTop_toBottomOf="@id/tv_total_distance"
             tools:text="5.1" />
 
         <TextView
@@ -206,7 +218,7 @@
             android:text="@string/end_run_distance_unit"
             android:textColor="@color/G1"
             android:textSize="14sp"
-            app:layout_constraintBottom_toBottomOf="@id/tv_time_data"
+            app:layout_constraintBottom_toBottomOf="@id/tv_distance_data"
             app:layout_constraintEnd_toEndOf="@id/tv_total_distance"
             app:layout_constraintStart_toEndOf="@id/tv_distance_data" />
 
@@ -214,59 +226,69 @@
             android:id="@+id/divider_vertical_rightOfDistance"
             android:layout_width="1dp"
             android:layout_height="0dp"
-            android:layout_marginEnd="20dp"
             android:background="@color/G2"
             app:layout_constraintBottom_toBottomOf="@id/tv_time_data"
-            app:layout_constraintEnd_toStartOf="@id/tv_time_data"
+            app:layout_constraintEnd_toEndOf="@id/view_1"
             app:layout_constraintTop_toTopOf="@id/tv_time" />
 
 
         <!--이동시간-->
 
+        <View
+            android:id="@+id/view_2"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/transparent_00"
+            app:layout_constraintBottom_toBottomOf="@id/view_1"
+            app:layout_constraintEnd_toStartOf="@id/view_3"
+            app:layout_constraintStart_toEndOf="@id/view_1"
+            app:layout_constraintTop_toTopOf="@id/view_1" />
 
         <TextView
             android:id="@+id/tv_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="30dp"
-            android:layout_marginBottom="7dp"
             android:fontFamily="@font/pretendard_medium"
             android:text="@string/end_run_time_title"
             android:textColor="@color/G2"
             android:textSize="13sp"
-            app:layout_constraintBottom_toTopOf="@id/tv_time_data"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/divider_endRun" />
+            app:layout_constraintEnd_toEndOf="@id/view_2"
+            app:layout_constraintStart_toStartOf="@id/view_2"
+            app:layout_constraintTop_toTopOf="@id/tv_total_distance" />
 
         <TextView
             android:id="@+id/tv_time_data"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="36dp"
             android:fontFamily="@font/pretendard_bold"
-            android:gravity="bottom"
             android:text="@{model.timerHourMinSec}"
             android:textColor="@color/G1"
             android:textSize="20sp"
-            app:layout_constraintBottom_toTopOf="@id/btn_endRun_save"
+            app:layout_constraintBottom_toBottomOf="@id/tv_distance_unit"
             app:layout_constraintEnd_toEndOf="@id/tv_time"
             app:layout_constraintStart_toStartOf="@id/tv_time"
-            app:layout_constraintTop_toBottomOf="@id/tv_time"
             tools:text="00:28:07" />
 
         <View
             android:id="@+id/divider_vertical_rightOfTime"
             android:layout_width="1dp"
             android:layout_height="0dp"
-            android:layout_marginStart="20dp"
             android:background="@color/G2"
             app:layout_constraintBottom_toBottomOf="@id/tv_time_data"
-            app:layout_constraintStart_toEndOf="@id/tv_time_data"
+            app:layout_constraintEnd_toEndOf="@id/view_2"
             app:layout_constraintTop_toTopOf="@id/tv_time" />
 
         <!--평균 페이스-->
 
+        <View
+            android:id="@+id/view_3"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/transparent_00"
+            app:layout_constraintBottom_toBottomOf="@id/view_2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/view_2"
+            app:layout_constraintTop_toTopOf="@id/view_2" />
 
         <TextView
             android:id="@+id/tv_pace"
@@ -276,17 +298,15 @@
             android:text="@string/end_run_pace_title"
             android:textColor="@color/G2"
             android:textSize="13sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/divider_vertical_rightOfTime"
+            app:layout_constraintEnd_toEndOf="@id/view_3"
+            app:layout_constraintStart_toStartOf="@id/view_3"
             app:layout_constraintTop_toTopOf="@id/tv_time" />
 
         <TextView
             android:id="@+id/tv_pace_data"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="7dp"
             android:fontFamily="@font/pretendard_bold"
-            android:gravity="bottom"
             android:text="@{model.paceTotal}"
             android:textColor="@color/G1"
             android:textSize="20sp"

--- a/app/src/main/res/layout/activity_my_history_detail.xml
+++ b/app/src/main/res/layout/activity_my_history_detail.xml
@@ -43,8 +43,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="6dp"
-                android:padding="10dp"
                 android:background="@color/W1"
+                android:padding="10dp"
                 android:src="@drawable/backbutton"
                 app:layout_constraintStart_toStartOf="@id/toolbar_history_detail"
                 app:layout_constraintTop_toTopOf="@id/toolbar_history_detail" />
@@ -56,8 +56,8 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
                 android:layout_marginEnd="18dp"
-                android:padding="10dp"
                 android:backgroundTint="@color/W1"
+                android:padding="10dp"
                 android:src="@drawable/showmorebtn" />
         </androidx.appcompat.widget.Toolbar>
 
@@ -187,10 +187,21 @@
             android:layout_width="match_parent"
             android:layout_height="7dp"
             android:layout_marginTop="80dp"
-            android:background="@color/G5"
+            app:dividerColor="@color/G5"
             app:layout_constraintTop_toBottomOf="@id/divider_course_title" />
 
         <!--총 거리-->
+
+        <View
+            android:id="@+id/view_1"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/transparent_00"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/view_2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/divider_history_info" />
+
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_total_distance"
             android:layout_width="wrap_content"
@@ -200,9 +211,10 @@
             android:text="@string/end_run_distance_title"
             android:textColor="@color/G2"
             android:textSize="13sp"
-            app:layout_constraintEnd_toEndOf="@id/divider_vertical_rightOfDistance"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/divider_history_info" />
+            app:layout_constraintBottom_toTopOf="@id/tv_distance_data"
+            app:layout_constraintEnd_toEndOf="@id/view_1"
+            app:layout_constraintStart_toStartOf="@id/view_1"
+            app:layout_constraintTop_toTopOf="@id/view_1" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_distance_data"
@@ -213,12 +225,11 @@
             android:text="@{vm.distance}"
             android:textColor="@color/G1"
             android:textSize="20sp"
-            app:layout_constraintBottom_toBottomOf="@id/tv_distance_unit"
             app:layout_constraintEnd_toStartOf="@id/tv_distance_unit"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="@id/tv_total_distance"
             app:layout_constraintTop_toBottomOf="@id/tv_total_distance"
-            tools:text="5.1" />
+            tools:text="5.1 km" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_distance_unit"
@@ -229,22 +240,31 @@
             android:text="@string/end_run_distance_unit"
             android:textColor="@color/G1"
             android:textSize="14sp"
-            app:layout_constraintBottom_toBottomOf="@id/tv_time_data"
+            app:layout_constraintBottom_toBottomOf="@id/tv_distance_data"
             app:layout_constraintEnd_toEndOf="@id/tv_total_distance"
             app:layout_constraintStart_toEndOf="@id/tv_distance_data" />
 
         <View
             android:id="@+id/divider_vertical_rightOfDistance"
             android:layout_width="0.7dp"
-            android:layout_height="44dp"
-            android:layout_marginEnd="20dp"
+            android:layout_height="0dp"
             android:background="@color/G2"
-            app:layout_constraintBottom_toBottomOf="@id/tv_time_data"
-            app:layout_constraintEnd_toStartOf="@id/tv_time_data"
-            app:layout_constraintTop_toTopOf="@id/tv_time" />
+            app:layout_constraintBottom_toBottomOf="@id/tv_distance_data"
+            app:layout_constraintEnd_toEndOf="@id/view_1"
+            app:layout_constraintTop_toTopOf="@id/tv_total_distance" />
 
 
         <!--이동시간-->
+
+        <View
+            android:id="@+id/view_2"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/transparent_00"
+            app:layout_constraintBottom_toBottomOf="@id/view_1"
+            app:layout_constraintEnd_toStartOf="@id/view_3"
+            app:layout_constraintStart_toEndOf="@id/view_1"
+            app:layout_constraintTop_toTopOf="@id/view_1" />
 
 
         <androidx.appcompat.widget.AppCompatTextView
@@ -255,35 +275,44 @@
             android:text="@string/end_run_time_title"
             android:textColor="@color/G2"
             android:textSize="13sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/tv_time_data"
+            app:layout_constraintEnd_toEndOf="@id/view_2"
+            app:layout_constraintStart_toStartOf="@id/view_2"
             app:layout_constraintTop_toTopOf="@id/tv_total_distance" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_time_data"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="7dp"
             android:fontFamily="@font/pretendard_bold"
             android:text="@{vm.time}"
             android:textColor="@color/G1"
             android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="@id/tv_distance_unit"
             app:layout_constraintEnd_toEndOf="@id/tv_time"
             app:layout_constraintStart_toStartOf="@id/tv_time"
-            app:layout_constraintTop_toBottomOf="@id/tv_time"
             tools:text="00:28:07" />
 
         <View
             android:id="@+id/divider_vertical_rightOfTime"
             android:layout_width="0.7dp"
-            android:layout_height="44dp"
-            android:layout_marginStart="20dp"
+            android:layout_height="0dp"
             android:background="@color/G2"
             app:layout_constraintBottom_toBottomOf="@id/tv_time_data"
-            app:layout_constraintStart_toEndOf="@id/tv_time_data"
+            app:layout_constraintEnd_toEndOf="@id/view_2"
             app:layout_constraintTop_toTopOf="@id/tv_time" />
 
         <!--평균 페이스-->
+
+        <View
+            android:id="@+id/view_3"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/transparent_00"
+            app:layout_constraintBottom_toBottomOf="@id/view_2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/view_2"
+            app:layout_constraintTop_toTopOf="@id/view_2" />
 
 
         <androidx.appcompat.widget.AppCompatTextView
@@ -294,15 +323,15 @@
             android:text="@string/end_run_pace_title"
             android:textColor="@color/G2"
             android:textSize="13sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/divider_vertical_rightOfTime"
+            app:layout_constraintBottom_toTopOf="@id/tv_pace_data"
+            app:layout_constraintEnd_toEndOf="@id/view_3"
+            app:layout_constraintStart_toStartOf="@id/view_3"
             app:layout_constraintTop_toTopOf="@id/tv_time" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_pace_data"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="7dp"
             android:fontFamily="@font/pretendard_bold"
             android:text="@{vm.pace}"
             android:textColor="@color/G1"
@@ -310,7 +339,6 @@
             app:layout_constraintBottom_toBottomOf="@id/tv_time_data"
             app:layout_constraintEnd_toEndOf="@id/tv_pace"
             app:layout_constraintStart_toStartOf="@id/tv_pace"
-            app:layout_constraintTop_toBottomOf="@id/tv_pace"
             tools:text="5’31’’" />
 
         <androidx.appcompat.widget.AppCompatTextView

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -46,7 +46,7 @@
             android:inputType="text"
             android:onTextChanged="@{model::getSearchKeyword}"
             android:textColor="@color/G1"
-            android:textSize="15sp"
+            android:textSize="17sp"
             app:layout_constraintBottom_toBottomOf="@id/imgBtn_back"
             app:layout_constraintStart_toEndOf="@id/imgBtn_back"
             app:layout_constraintTop_toTopOf="@id/imgBtn_back" />

--- a/app/src/main/res/layout/fragment_course_main.xml
+++ b/app/src/main/res/layout/fragment_course_main.xml
@@ -39,7 +39,6 @@
             android:id="@+id/tv_main_guide"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="7dp"
             android:elevation="3dp"
             android:fontFamily="@font/pretendard_medium"
             android:outlineProvider="none"
@@ -54,9 +53,7 @@
         <FrameLayout
             android:id="@+id/mapView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            tools:layout_editor_absoluteX="-46dp"
-            tools:layout_editor_absoluteY="0dp" />
+            android:layout_height="match_parent"  />
 
         <View
             android:id="@+id/view_empty"

--- a/app/src/main/res/layout/item_mypage_history.xml
+++ b/app/src/main/res/layout/item_mypage_history.xml
@@ -16,26 +16,29 @@
             android:id="@+id/iv_my_page_history_frame"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:background="@drawable/my_page_history_frame_selector"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="330:162"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:background="@drawable/my_page_history_frame_selector"/>
+            app:layout_constraintTop_toTopOf="parent" />
+
         <androidx.cardview.widget.CardView
             android:id="@+id/cv_my_page_history_course"
             android:layout_width="80dp"
             android:layout_height="0dp"
-            app:layout_constraintDimensionRatio="1:1"
             android:layout_marginStart="18dp"
             android:layout_marginTop="10dp"
             app:cardCornerRadius="10dp"
+            app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintStart_toStartOf="@id/iv_my_page_history_frame"
             app:layout_constraintTop_toTopOf="@id/iv_my_page_history_frame">
+
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/iv_my_page_history_course"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:scaleType="centerCrop"/>
+                android:scaleType="centerCrop" />
         </androidx.cardview.widget.CardView>
 
         <androidx.appcompat.widget.AppCompatTextView
@@ -90,83 +93,99 @@
             android:id="@+id/divider_my_page_history_horizontal1"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="18dp"
             android:layout_marginTop="9dp"
             android:scaleType="fitXY"
-            app:srcCompat="@drawable/my_page_history_divider"
-            android:layout_marginHorizontal="18dp"
-            app:layout_constraintStart_toStartOf="@id/iv_my_page_history_frame"
             app:layout_constraintEnd_toEndOf="@id/iv_my_page_history_frame"
-            app:layout_constraintTop_toBottomOf="@id/cv_my_page_history_course" />
+            app:layout_constraintStart_toStartOf="@id/iv_my_page_history_frame"
+            app:layout_constraintTop_toBottomOf="@id/cv_my_page_history_course"
+            app:srcCompat="@drawable/my_page_history_divider" />
 
 
         <View
             android:id="@+id/divider_my_page_history_vertical2"
             android:layout_width="1dp"
             android:layout_height="0dp"
-            android:layout_marginStart="112dp"
-            android:layout_marginTop="12dp"
-            android:layout_marginBottom="20.71dp"
             android:background="@color/G4"
             android:orientation="vertical"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/divider_my_page_history_horizontal1" />
+            app:layout_constraintBottom_toBottomOf="@id/tv_my_page_history_distance_data"
+            app:layout_constraintEnd_toEndOf="@id/view_1"
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_history_distance" />
 
         <View
             android:id="@+id/divider_my_page_history_vertical3"
             android:layout_width="1dp"
             android:layout_height="0dp"
-            android:layout_marginTop="12dp"
-            android:layout_marginEnd="112dp"
-            android:layout_marginBottom="20.71dp"
             android:background="@color/G4"
             android:orientation="vertical"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/tv_my_page_history_time_data"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/divider_my_page_history_horizontal1" />
+            app:layout_constraintStart_toStartOf="@id/view_2"
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_history_time" />
 
         <!--총 거리-->
+
+        <View
+            android:id="@+id/view_1"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/transparent_00"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/view_2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/divider_my_page_history_horizontal1" />
+
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_my_page_history_distance"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="14dp"
+            android:layout_marginTop="16dp"
             android:fontFamily="@font/pretendard_regular"
             android:text="@string/item_mypage_history_distance"
             android:textColor="@color/G2"
             android:textSize="11sp"
+            app:layout_constraintBottom_toTopOf="@id/tv_my_page_history_distance_data"
+            app:layout_constraintEnd_toEndOf="@id/view_1"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="@id/divider_my_page_history_vertical2"
-            app:layout_constraintTop_toBottomOf="@id/divider_my_page_history_horizontal1" />
+            app:layout_constraintTop_toTopOf="@id/view_1" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_my_page_history_distance_data"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
+            android:layout_marginTop="8dp"
             android:fontFamily="@font/pretendard_semibold"
             android:textColor="@color/G1"
             android:textSize="13sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="@id/divider_my_page_history_vertical2"
+            app:layout_constraintEnd_toEndOf="@id/tv_my_page_history_distance"
+            app:layout_constraintStart_toStartOf="@id/tv_my_page_history_distance"
             app:layout_constraintTop_toBottomOf="@id/tv_my_page_history_distance"
-            tools:text="4.01" />
+            tools:text="4.01 km" />
 
+
+        <!--이동 시간-->
+        <View
+            android:id="@+id/view_2"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/transparent_00"
+            app:layout_constraintBottom_toBottomOf="@id/view_1"
+            app:layout_constraintEnd_toStartOf="@id/view_3"
+            app:layout_constraintStart_toEndOf="@id/view_1"
+            app:layout_constraintTop_toTopOf="@id/view_1" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_my_page_history_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="14dp"
             android:fontFamily="@font/pretendard_regular"
             android:text="@string/item_mypage_history_time"
             android:textColor="@color/G2"
             android:textSize="11sp"
             app:layout_constraintEnd_toEndOf="@id/divider_my_page_history_vertical3"
             app:layout_constraintStart_toEndOf="@id/divider_my_page_history_vertical2"
-            app:layout_constraintTop_toBottomOf="@id/divider_my_page_history_horizontal1" />
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_history_distance" />
 
-        <!--평균 페이스-->
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_my_page_history_time_data"
             android:layout_width="wrap_content"
@@ -175,23 +194,34 @@
             android:textColor="@color/G1"
             android:textSize="13sp"
             app:layout_constraintBottom_toBottomOf="@id/tv_my_page_history_distance_data"
-            app:layout_constraintEnd_toStartOf="@id/divider_my_page_history_vertical3"
+            app:layout_constraintEnd_toEndOf="@id/tv_my_page_history_time"
             app:layout_constraintHorizontal_bias="0.521"
-            app:layout_constraintStart_toEndOf="@id/divider_my_page_history_vertical2"
+            app:layout_constraintStart_toStartOf="@id/tv_my_page_history_time"
             tools:text="0:27:36" />
 
-        <androidx.appcompat.widget.AppCompatTextView
+        <!--평균 페이스-->
+
+        <View
+            android:id="@+id/view_3"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/transparent_00"
+            app:layout_constraintBottom_toBottomOf="@id/view_2"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/view_2"
+            app:layout_constraintTop_toTopOf="@id/view_2" />
+
+        <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_my_page_history_pace"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="14dp"
             android:fontFamily="@font/pretendard_regular"
             android:text="@string/item_mypage_history_pace"
             android:textColor="@color/G2"
             android:textSize="12sp"
-            app:layout_constraintStart_toEndOf="@id/divider_my_page_history_vertical3"
-            app:layout_constraintTop_toTopOf="@id/divider_my_page_history_horizontal1" />
+            app:layout_constraintEnd_toEndOf="@id/view_3"
+            app:layout_constraintStart_toStartOf="@id/view_3"
+            app:layout_constraintTop_toTopOf="@id/tv_my_page_history_time" />
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/tv_my_page_history_pace_data"
@@ -201,8 +231,8 @@
             android:textColor="@color/G1"
             android:textSize="13sp"
             app:layout_constraintBottom_toBottomOf="@id/tv_my_page_history_time_data"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/divider_my_page_history_vertical3"
+            app:layout_constraintEnd_toEndOf="@id/tv_my_page_history_pace"
+            app:layout_constraintStart_toStartOf="@id/tv_my_page_history_pace"
             tools:text="6’45”" />
 
 


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#136 [fix] 거리/이동시간/평균페이스 표기하는 UI 간격 통일
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
투명한 박스를 3개 만들고 각각에 constraint를 걸고 width를 0dp로 주면 3개가 화면 가로 길이를 3등분하는데 이걸 이용해서 3등분된 박스 안에다 텍스트를 집어넣어주고 제약 조건을 걸어주었음.
## 📸 스크린샷(선택)
<!-- 추가 설명이 필요한 경우 스크린샷을 첨부해주세요 -->

![Screenshot_20230522-142331_Runnect](https://github.com/Runnect/Runnect-Android/assets/89737271/0dbe4a85-9212-4882-9592-0ce661adfcb7)
![Screenshot_20230522-142335_Runnect](https://github.com/Runnect/Runnect-Android/assets/89737271/19499270-092f-4967-be2a-7d285b10f709)
![Screenshot_20230522-142348_Runnect](https://github.com/Runnect/Runnect-Android/assets/89737271/d4d658ad-17b3-4caf-aea4-c10e1d2df722)
