### PR TITLE
[Ui] 기록 상세 지도 이미지 조정

### DIFF
--- a/app/src/main/res/layout/activity_my_history_detail.xml
+++ b/app/src/main/res/layout/activity_my_history_detail.xml
@@ -68,7 +68,7 @@
             android:background="@color/G3"
             android:scaleType="centerCrop"
             app:imgUri="@{vm.mapImg}"
-            app:layout_constraintDimensionRatio="360:443"
+            app:layout_constraintDimensionRatio="360:410"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar_history_detail" />


### PR DESCRIPTION
지도의 크기때문에 디스플레이 높이가 낮은 기기에서는 일부 뷰가 잘려 보이는 문제 발생

## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#138 기록 상세 지도 이미지 조정
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
기록 상세 지도 이미지 조정
## 📸 스크린샷(선택)
<!-- 추가 설명이 필요한 경우 스크린샷을 첨부해주세요 -->
![image](https://github.com/Runnect/Runnect-Android/assets/70442964/6c2d1ce3-4f94-48c0-8d65-281ab7093f47)
![image](https://github.com/Runnect/Runnect-Android/assets/70442964/d96a2b60-52de-4640-8c24-411b6a8d0ca8)
