### PR TITLE
#177 [fix] onDestroy에 stopTimer() 추가

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/run/RunActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/run/RunActivity.kt
@@ -1,6 +1,5 @@
 package com.runnect.runnect.presentation.run
 
-import android.content.ContentValues
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.PointF
@@ -81,6 +80,11 @@ class RunActivity :
         stopTimer()
         finish()
         overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        stopTimer()
     }
 
     private fun backButton() {
@@ -296,18 +300,7 @@ class RunActivity :
             timerMinute = minute
             timerSecond = second
 
-            Timber.tag(ContentValues.TAG).d("timerHour 값 : $timerHour")
-            Timber.tag(ContentValues.TAG).d("timerMinute 값 : $timerMinute")
-            Timber.tag(ContentValues.TAG).d("timerSecond 값 : $timerSecond")
-
-            Timber.tag(ContentValues.TAG)
-                .d("binding.tvTimeHour.text 값 : ${binding.tvTimeHour.text}")
-            Timber.tag(ContentValues.TAG)
-                .d("binding.tvTimeMinute.text 값 : ${binding.tvTimeMinute.text}")
-            Timber.tag(ContentValues.TAG)
-                .d("binding.tvTimeSecond.text 값 : ${binding.tvTimeSecond.text}")
-
-
+            Timber.tag("Timer").d("$timerHour:$timerMinute:$timerSecond")
         }
     }
 


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#177 타이머 뒤로가기 시 stop 안 되는 이슈

제스쳐로 뒤로가기 시 onBackPressed()에 정의해준 stopTimer()가 적용 안 되었고, 해당 뷰에서 exit했는데도 timer가 계속 돌아서 리소스가 낭비되는 문제가 있었음. onDestroy에 stopTimer를 추가해줌으로써 문제를 해결하였음.

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- onDestroy에 stopTimer 추가