### PR TITLE
Fix/181 코스 발견 배너 페이지 관련 이슈

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -302,8 +302,6 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     }
 
     override fun selectBanner(item: DiscoverPromotionItemDTO) {
-        Timber.tag("Banner").d("item_index : ${item.index}")
-
         if (item.linkUrl.isNotEmpty()) {
             requireContext().startWebView(item.linkUrl)
         }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -196,32 +196,33 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     }
 
     private fun setPromotion(vp: ViewPager2, vpList: MutableList<DiscoverPromotionItemDTO>) {
-        setPromotionAdapter(vpList)
-        setPromotionIndicator(vp)
-        setPromotionViewPager(vp)
+        val bannerCount = vpList.size
+        setPromotionAdapter(vpList,bannerCount)
+        setPromotionIndicator(vp,bannerCount)
+        setPromotionViewPager(vp,bannerCount)
         setScrollHandler(vp)
     }
 
-    private fun setPromotionAdapter(vpList: MutableList<DiscoverPromotionItemDTO>) {
+    private fun setPromotionAdapter(vpList: MutableList<DiscoverPromotionItemDTO>, bannerCount: Int) {
         promotionAdapter = DiscoverPromotionAdapter(requireContext(), this)
         promotionAdapter.submitList(vpList)
         binding.vpDiscoverPromotion.adapter = promotionAdapter
-        setPromotionIndicator(binding.vpDiscoverPromotion)
+        setPromotionIndicator(binding.vpDiscoverPromotion, bannerCount)
     }
 
-    private fun setPromotionIndicator(vp: ViewPager2) {
+    private fun setPromotionIndicator(vp: ViewPager2, bannerCount: Int) {
         val indicator = binding.ciDiscoverPromotion
         indicator.setViewPager(vp)
-        indicator.createIndicators(FRAME_NUM, PAGE_NUM / 2)
+        indicator.createIndicators(bannerCount, PAGE_NUM / 2)
     }
 
-    private fun setPromotionViewPager(vp: ViewPager2) {
+    private fun setPromotionViewPager(vp: ViewPager2, bannerCount: Int) {
         vp.orientation = ViewPager2.ORIENTATION_HORIZONTAL
         vp.setCurrentItem(PAGE_NUM / 2, false)
         vp.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-                binding.ciDiscoverPromotion.animatePageSelected(position % FRAME_NUM)
+                binding.ciDiscoverPromotion.animatePageSelected(position % bannerCount)
                 currentPosition = position
             }
 
@@ -232,7 +233,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
             ) {
                 super.onPageScrolled(position, positionOffset, positionOffsetPixels)
                 if (positionOffsetPixels == 0) {
-                    binding.ciDiscoverPromotion.animatePageSelected(position % FRAME_NUM)
+                    binding.ciDiscoverPromotion.animatePageSelected(position % bannerCount)
                 }
             }
         }
@@ -309,7 +310,6 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     }
 
     companion object {
-        const val FRAME_NUM = 3
         const val PAGE_NUM = 900
         const val INTERVAL_TIME = 5000L
         const val COURSE_DISCOVER_TAG = "discover"


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#181 코스 발견 배너 페이지 관련 이슈
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
파이어 베이스를 통해 배너 이미지를 삽입하게 되면서, 파이어 베이스에서 제공받는 이미지의 수와 고정되어있던 PAGE 수가 맞지 않아, 고정 PAGE 수가 초과하는 개수만큼의 빈 배너가 발생하는 이슈
=> 페이지 개수 고정값 FRAME_NUM을 vpList.size로 대체하여 해결
