### PR TITLE
#198 [fix] timer minute logic 수정

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/run/TimerService.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/run/TimerService.kt
@@ -32,7 +32,7 @@ class TimerService : Service() {
                 time++
 
                 val hour = time / 3600
-                val minute = time / 60
+                val minute = (time % 3600) / 60
                 val second = time % 60
 
                 val timerValue = String.format("%02d:%02d:%02d", hour, minute, second)


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#198 timer '분' 셋째자리까지 표기되는 이슈가 있어 대응 작업을 해주었습니다.

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
timer '분' logic 수정

before)
val minute = time / 60

after)
val minute = (time % 3600) / 60
