### PR TITLE
#206 [fix] 코스발견에서 빠르게 다른 fragment menu로 전환 시 앱이 죽는 이슈

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -267,8 +267,15 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
         timer.schedule(timerTask, INTERVAL_TIME, INTERVAL_TIME)
     }
 
+    //timerTask 객체가 delay(600) 뒤에 생성되는데 그 전에 다른 fragment로 menu를 전환하면 생성되지도 않은 timerTask를 cancel하려는 것이니 NPE가 뜹니다.
+    //따라서 delay(700)을 줘서 임시조치를 취해놨습니다.
     private fun autoScrollStop() {
-        timerTask.cancel()
+        lifecycleScope.launch {
+            delay(700)
+            if (::timerTask.isInitialized) {
+                timerTask.cancel()
+            }
+        }
     }
 
     override fun onResume() {


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#206 코스발견에서 빠르게 다른 fragment menu로 전환 시 앱이 죽는 이슈
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
timerTask 객체가 delay(600) 뒤에 생성되는데 그 전에 다른 fragment로 menu를 전환하면 생성되지도 않은 timerTask를 cancel하려는 것이니 NPE가 뜹니다.

여기 배너 timer 관련 코드는 지훈이가 이번주에 개인 일정 끝내고 fix를 해주기로 했는데 그 전에 임시로 delay(700)을 주어 앱이 죽지 않게 조치를 취해놨습니다.

추후 timer 관련 코드 수정 후 코루틴을 사용하여 비동기적으로 처리되는 logic들 간의 순서를 맞춰주면 될 것 같습니다.