### PR TITLE
Fix/209 코스발견 상단 배너 스크롤 타이머 로직 수정2

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/service/TokenAuthenticator.kt
+++ b/app/src/main/java/com/runnect/runnect/data/service/TokenAuthenticator.kt
@@ -2,9 +2,12 @@ package com.runnect.runnect.data.service
 
 import android.content.Context
 import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import android.widget.Toast
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.runnect.runnect.BuildConfig
+import com.runnect.runnect.R
 import com.runnect.runnect.application.ApplicationClass
 import com.runnect.runnect.application.PreferenceManager
 import com.runnect.runnect.presentation.login.LoginActivity
@@ -27,7 +30,9 @@ class TokenAuthenticator(val context: Context) : Authenticator {
         if (response.code == 401) {
             if (response.message == "Unauthorized") {
                 clearToken()
-                Toast.makeText(context,"장기간 미접속으로 인해 재로그인이 필요합니다.",Toast.LENGTH_LONG).show()
+                Handler(Looper.getMainLooper()).post{
+                    Toast.makeText(context,context.getString(R.string.alert_need_to_re_sign),Toast.LENGTH_LONG).show()
+                }
                 val intent = Intent(context, LoginActivity::class.java)
                 intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 context.startActivity(intent)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,4 +114,5 @@
     <string name="give_nickname_title_3">이름을 입력해주세요</string>
     <string name="give_nickname_edit_input">닉네임을 입력해주세요</string>
     <string name="give_nickname_finish">시작하기</string>
+    <string name="alert_need_to_re_sign">장기간 미접속으로 인해 재로그인이 필요합니다.</string>
 </resources>


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#209 코스발견 상단 배너 스크롤 타이머 로직 수정2
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
상단 배너 초기화 로직인 setPromotion 메소드가 비대해짐에 따라 발생한 비효율적인 로직 개선
배너 자동 스크롤에 사용되는 timer 및 timerTask의 초기화 관련 이슈 해결
 - 초기화 로직과 비즈니스 로직의 분리
 - 메소드 명 변경 setPromotion -> setPromotionBanner
 - timer 및 timerTask의 초기화 여부에 따른 예외처리
번외 : Toast 메시지 표시가 UI Thread에서 이루어지도록 수정