### PR TITLE
Feature/188 paging discover recommend course

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/dto/RecommendCourseDTO.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/RecommendCourseDTO.kt
@@ -1,6 +1,7 @@
 package com.runnect.runnect.data.dto
 
 data class RecommendCourseDTO(
+    val pageNo: String?,
     val courseId: Int,
     val departure: String,
     val id: Int,

--- a/app/src/main/java/com/runnect/runnect/data/dto/RecommendCourseDTO.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/RecommendCourseDTO.kt
@@ -1,7 +1,7 @@
 package com.runnect.runnect.data.dto
 
 data class RecommendCourseDTO(
-    val pageNo: String?,
+    val pageNo: Int,
     val courseId: Int,
     val departure: String,
     val id: Int,

--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseRecommendCourse.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseRecommendCourse.kt
@@ -11,7 +11,7 @@ data class ResponseRecommendCourse(
 
 @Serializable
 data class RecommendPublicCourse(
-    val pageNo: String?,
+    val pageNo: Int,
     val courseId: Int,
     val departure: RecommendDeparture,
     val id: Int,

--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseRecommendCourse.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseRecommendCourse.kt
@@ -11,6 +11,7 @@ data class ResponseRecommendCourse(
 
 @Serializable
 data class RecommendPublicCourse(
+    val pageNo: String?,
     val courseId: Int,
     val departure: RecommendDeparture,
     val id: Int,

--- a/app/src/main/java/com/runnect/runnect/data/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/com/runnect/runnect/data/repository/CourseRepositoryImpl.kt
@@ -26,9 +26,9 @@ import javax.inject.Inject
 
 class CourseRepositoryImpl @Inject constructor(private val remoteCourseDataSource: RemoteCourseDataSource) :
     CourseRepository {
-    override suspend fun getRecommendCourse(): MutableList<RecommendCourseDTO> {
+    override suspend fun getRecommendCourse(pageNo: String?): MutableList<RecommendCourseDTO> {
         val recommendCourse = mutableListOf<RecommendCourseDTO>()
-        for (i in remoteCourseDataSource.getRecommendCourse().data.publicCourses) {
+        for (i in remoteCourseDataSource.getRecommendCourse(pageNo = pageNo).data.publicCourses) {
             recommendCourse.add(i.toData())
         }
         return recommendCourse

--- a/app/src/main/java/com/runnect/runnect/data/service/CourseService.kt
+++ b/app/src/main/java/com/runnect/runnect/data/service/CourseService.kt
@@ -15,7 +15,8 @@ import retrofit2.http.*
 interface CourseService {
     @GET("/api/public-course")
     suspend fun getRecommendCourse(
-    ): ResponseRecommendCourse
+        @Query("pageNo") pageNo: String?,
+        ): ResponseRecommendCourse
 
     @POST("/api/scrap")
     suspend fun postCourseScrap(

--- a/app/src/main/java/com/runnect/runnect/data/source/remote/RemoteCourseDataSource.kt
+++ b/app/src/main/java/com/runnect/runnect/data/source/remote/RemoteCourseDataSource.kt
@@ -13,7 +13,7 @@ import okhttp3.RequestBody
 import javax.inject.Inject
 
 class RemoteCourseDataSource @Inject constructor(private val courseService: CourseService) {
-    suspend fun getRecommendCourse(): ResponseRecommendCourse = courseService.getRecommendCourse()
+    suspend fun getRecommendCourse(pageNo: String?): ResponseRecommendCourse = courseService.getRecommendCourse(pageNo = pageNo)
     suspend fun postCourseScrap(requestCourseScrap: RequestCourseScrap): ResponseCourseScrap =
         courseService.postCourseScrap(requestCourseScrap)
 

--- a/app/src/main/java/com/runnect/runnect/domain/CourseRepository.kt
+++ b/app/src/main/java/com/runnect/runnect/domain/CourseRepository.kt
@@ -21,7 +21,7 @@ import okhttp3.RequestBody
 import retrofit2.Response
 
 interface CourseRepository {
-    suspend fun getRecommendCourse(): MutableList<RecommendCourseDTO>
+    suspend fun getRecommendCourse(pageNo: String?): MutableList<RecommendCourseDTO>
     suspend fun postCourseScrap(requestCourseScrap: RequestCourseScrap): ResponseCourseScrap
     suspend fun getCourseSearch(keyword: String): MutableList<CourseSearchDTO>
     suspend fun getCourseDetail(publicCourseId: Int): CourseDetailDTO

--- a/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
@@ -156,7 +156,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         var discoverFragment: DiscoverFragment? = null
         var storageScrapFragment: StorageScrapFragment? = null
         fun updateDiscoverFragment() {
-            discoverFragment?.getRecommendCourses()
+            discoverFragment?.getRecommendCourses(pageNo = "")
         }
 
         fun updateStorageScrap() {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.os.Parcelable
 import android.view.View
 import androidx.activity.addCallback
 import androidx.activity.result.ActivityResultLauncher
@@ -15,7 +14,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.GridLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.runnect.runnect.R
 import com.runnect.runnect.binding.BindingFragment
@@ -58,8 +56,6 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     var isFromStorageScrap = StorageScrapFragment.isFromStorageNoScrap
     var isVisitorMode: Boolean = MainActivity.isVisitorMode
 
-    var recyclerViewState: Parcelable? = null
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -99,6 +95,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
 
     private fun pullToRefresh() {
         binding.refreshLayout.setOnRefreshListener {
+            viewModel.recommendCourseList.clear() //새로고침 시 다시 pageNo가 1부터 시작되는데 기존에 끝까지 받아온 거에 addAll로 계속 누적돼서 clear()로 비워주는 것.
             getRecommendCourses(pageNo = "1")
             binding.refreshLayout.isRefreshing = false
         }
@@ -188,6 +185,10 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
                 UiState.Failure -> {
                     Timber.tag(ContentValues.TAG)
                         .d("Failure : ${viewModel.errorMessage.value}")
+                    if (viewModel.errorMessage.value == END_PAGE) {
+                        binding.shimmerLayout.stopShimmer()
+                        binding.shimmerLayout.isVisible = false
+                    }
                 }
             }
         }
@@ -352,5 +353,6 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
         const val COURSE_DISCOVER_TAG = "discover"
         const val EXTRA_PUBLIC_COURSE_ID = "publicCourseId"
         const val EXTRA_ROOT = "root"
+        const val END_PAGE = "HTTP 400 Bad Request"
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -27,7 +27,7 @@ class DiscoverViewModel @Inject constructor(
         get() = _courseInfoState
 
     private var _recommendCourseList = mutableListOf<RecommendCourseDTO>()
-    val recommendCourseList: List<RecommendCourseDTO>
+    val recommendCourseList: MutableList<RecommendCourseDTO>
         get() = _recommendCourseList
 
     val currentPageNo = MutableLiveData<Int>()

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -30,6 +30,8 @@ class DiscoverViewModel @Inject constructor(
     val recommendCourseList: List<RecommendCourseDTO>
         get() = _recommendCourseList
 
+    val currentPageNo = MutableLiveData<Int>()
+
     val errorMessage = MutableLiveData<String>()
 
     var bannerData = mutableListOf<DiscoverPromotionItemDTO>()
@@ -64,10 +66,12 @@ class DiscoverViewModel @Inject constructor(
                 _courseInfoState.value = UiState.Loading
                 courseRepository.getRecommendCourse(pageNo = pageNo)
             }.onSuccess {
-                _recommendCourseList = it
+                _recommendCourseList.addAll(it)
+                currentPageNo.value = it[0].pageNo
                 _courseInfoState.value = UiState.Success
                 Timber.tag(ContentValues.TAG).d("데이터 수신 완료")
             }.onFailure {
+                Timber.tag(ContentValues.TAG).d("데이터 수신 실패")
                 errorMessage.value = it.message
                 _courseInfoState.value = UiState.Failure
             }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -58,11 +58,11 @@ class DiscoverViewModel @Inject constructor(
         }
     }
 
-    fun getRecommendCourse() {
+    fun getRecommendCourse(pageNo: String?) {
         viewModelScope.launch {
             runCatching {
                 _courseInfoState.value = UiState.Loading
-                courseRepository.getRecommendCourse()
+                courseRepository.getRecommendCourse(pageNo = pageNo)
             }.onSuccess {
                 _recommendCourseList = it
                 _courseInfoState.value = UiState.Success

--- a/app/src/main/java/com/runnect/runnect/util/extension/ResponseExt.kt
+++ b/app/src/main/java/com/runnect/runnect/util/extension/ResponseExt.kt
@@ -25,12 +25,13 @@ fun PublicCourseUpload.toData(): UserUploadCourseDTO {
 
 fun RecommendPublicCourse.toData(): RecommendCourseDTO {
     return RecommendCourseDTO(
+        pageNo = pageNo,
         courseId = courseId,
         departure = departure.region + ' ' + departure.city,
         id = id,
         title = title,
         scrap = scrap,
-        image = image,
+        image = image
     )
 }
 

--- a/app/src/main/res/layout/fragment_discover.xml
+++ b/app/src/main/res/layout/fragment_discover.xml
@@ -47,6 +47,7 @@
 
 
             <androidx.core.widget.NestedScrollView
+                android:id="@+id/nestedScrollView"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:orientation="vertical"


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#188 코스 발견-추천에 paging 적용
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
data가 많아질수록 loading 시간이 오래 걸려 사용성이 저하될까봐 서버에 page로 끊어서 보내달라고 요청했습니다.

## ✨ 고민됐던 내용(질문)
<!--어떤 작업을 했는지 작성해주세요-->
처음엔 paging 라이브러리를 쓰려고 했는데 스크롤을 안 내렸는데도 계속 다음 page data를 받아오는 통신 함수가 실행되는 문제가 있었습니다. 원인 파악을 못해서 paging 라이브러리를 버리고 addOnScrollListener를 활용해 스크롤이 끝까지 내려가면 통신 함수를 돌리는 식으로 직접 코드를 짜주었습니다.

그런데 여기서도 paging 라이브러리 때와 같은 문제가 발생하였고 다른 방법을 찾아보다가 리사이클러뷰의 addOnScrollListener가 아닌 nestedScrollView의 setOnScrollChangeListener로 처리하니까 해결이 돼서 이 방법을 채택해주었습니다.

추측하기론 리사이클러뷰가 nestedScrollView 안에 묶여있는 것이 어떤 문제를 초래한 것 같은데 뭐가 원인이었는지 잘 모르겠습니다.  혹시 알고 계신 바가 있을까요?

## ✨ 보충할 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 서버에 response로 endPage 여부를 알려주는 true/false 값을 보내달라고 수정 요청하여 이것으로 분기 처리를 해줄 예정입니다.
- 한 page당 data를 몇개 단위로 보내달라고 해야 할지 감이 안 잡혀 24개로 요청했는데 더 크게 묶어도 될 것 같습니다. 일단은 50개 정도로 수정 요청 예정입니다.
## 📸 스크린샷
<!-- 추가 설명이 필요한 경우 스크린샷을 첨부해주세요 -->


https://github.com/Runnect/Runnect-Android/assets/89737271/a40d79cc-615b-4d59-86ef-2d2e71f42276

