### PR TITLE
[chore] unregisterPageChangeCallback 메소드 호출 추가

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -51,6 +51,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     private lateinit var timer: Timer
     private lateinit var timerTask: TimerTask
     private lateinit var scrollPageRunnable: Runnable
+    private lateinit var pageRegisterCallback:ViewPager2.OnPageChangeCallback
     private var currentPosition = PAGE_NUM / 2
 
     var isFromStorageScrap = StorageScrapFragment.isFromStorageNoScrap
@@ -233,7 +234,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     }
 
     private fun registerPromotionPageCallback(vp: ViewPager2) {
-        vp.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+        pageRegisterCallback = object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
                 binding.ciDiscoverPromotion.animatePageSelected(position % viewModel.bannerCount)
@@ -251,7 +252,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
                 }
             }
         }
-        )
+        vp.registerOnPageChangeCallback(pageRegisterCallback)
     }
 
     private fun setScrollHandler() {
@@ -293,6 +294,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     override fun onPause() {
         super.onPause()
         autoScrollStop()
+        binding.vpDiscoverPromotion.unregisterOnPageChangeCallback(pageRegisterCallback)
     }
 
     override fun scrapCourse(id: Int?, scrapTF: Boolean) {


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
#215 viewPage에 할당된 pageChangeCallback을 생명주기에 따라 unRegister 해줌으로써 fragment 전환 시 발생하는 메모리 누수 해결
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
 -  callback 변수 분리
 -  unregisterOnPageCallback 메소드 호출
## 📸 스크린샷(선택)
<!-- 추가 설명이 필요한 경우 스크린샷을 첨부해주세요 -->

https://github.com/Runnect/Runnect-Android/assets/70442964/a24585b5-25ae-42b6-bf9f-e2f82b7ae18e

