### PR TITLE
[FIX] 보관함 / TabLayout 밑줄 안 뜨는 버그

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMainFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMainFragment.kt
@@ -84,7 +84,6 @@ class StorageMainFragment :
                             replace<StorageScrapFragment>(R.id.fl_main)
                             Timber.tag("hu").d("스크랩으로 이동하였음")
                         }
-
                         else -> IllegalArgumentException("${this::class.java.simpleName} Not found menu item id")
                     }
                 }

--- a/app/src/main/res/layout/fragment_storage_main.xml
+++ b/app/src/main/res/layout/fragment_storage_main.xml
@@ -15,7 +15,6 @@
         android:layout_height="match_parent"
         tools:context=".presentation.storage.StorageActivity">
 
-
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/storage_toolbar"
             android:layout_width="match_parent"
@@ -35,8 +34,6 @@
                 android:text="@string/storage_main_page_title"
                 android:textColor="@color/G1"
                 android:textSize="20sp" />
-
-
         </androidx.appcompat.widget.Toolbar>
 
         <com.google.android.material.tabs.TabLayout
@@ -51,7 +48,7 @@
             app:layout_constraintTop_toBottomOf="@id/storage_toolbar"
             app:tabGravity="fill"
             app:tabIndicatorColor="@color/M1"
-            app:tabIndicatorHeight="2dp"
+            app:tabIndicatorHeight="3dp"
             app:tabRippleColor="@null"
             app:tabSelectedTextColor="@color/M1"
             app:tabTextAppearance="@style/tab_text"
@@ -68,8 +65,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/storage_main_tab_scrap" />
-
-
         </com.google.android.material.tabs.TabLayout>
 
         <ImageView
@@ -121,8 +116,10 @@
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_marginHorizontal="15dp"
-            android:background="@color/G3"
-            app:layout_constraintTop_toBottomOf="@id/storage_tab" />
+            android:background="@color/G4"
+            android:elevation="1dp"
+            android:outlineProvider="none"
+            app:layout_constraintBottom_toBottomOf="@id/storage_tab" />
 
         <FrameLayout
             android:id="@+id/fl_main"
@@ -137,7 +134,6 @@
             android:layout_height="57dp"
             android:background="@color/transparent_00"
             app:layout_constraintBottom_toBottomOf="parent" />
-
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
closed #249 [FIX] 보관함 / TabLayout 밑줄 수정 (색상, elevation)
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 명확한 원인 파악은 못했지만 elevation을 조절해주니 해결됐음
- underLine color G3 -> G4
## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
왼쪽 이미지: 이번에 pr 올리는 코드
우측 이미지: 피그마 디자인 요구 사항

디자인 요구는 회색 underLine 바로 위를 보라색 밑줄이 덮는 건데 그렇게 못해냈습니다.
자세히 보시면 왼쪽은 덮는 게 아니라 위에 쌓여있습니다.

회색줄이 보라색줄을 덮고있으므로 보라색줄(tabLayout) elevation을 더 높게 주었더니 tabLayout 전체의 elevation이 높아져서 회색줄 자체를 아예 안 보이게 덮어버립니다. 그래서 elevation은 똑같이 맞춰주었고 대신 보라색줄 2dp중 1dp만큼을 회색줄이 덮어버리기 때문에 보정으로 보라색줄을 3dp로 설정해주었습니다 (3dp-1dp=2dp)

엄청 얇기 때문에 사실 말 안 하면 모를 이슈이긴 한데 그래도 일단 요구대로 온전히 구현해내지 못했으니 이슈 공유 해봅니다!
혹시 제가 놓친 부분이 있을까요? 

## 📸 스크린샷/동영상
<!--스크린샷을 첨부해주세요 불필요한 경우 생략 가능합니다-->
<img src="https://github.com/Runnect/Runnect-Android/assets/89737271/8a75ade8-eebb-45a2-a51b-157ace6cbf2b" width="40%">
<img src="https://github.com/Runnect/Runnect-Android/assets/89737271/09b8e606-347f-4920-8778-327b535d3e89" width="40%">
