### PR TITLE
[DEL] 출발지 검색 / 불필요한 onTextChanged 관련 코드 제거

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/search/SearchActivity.kt
@@ -139,6 +139,7 @@ class SearchActivity :
                     hideLoadingBar()
                     showSearchResult()
                 }
+
                 UiState.Failure -> {
                     hideLoadingBar()
                     showErrorMessage()
@@ -154,7 +155,7 @@ class SearchActivity :
 
     private fun imgBtnSearch() {
         binding.imgBtnSearch.setOnClickListener {
-            viewModel.getSearchList(viewModel.searchKeyword.value.toString())
+            viewModel.getSearchList(binding.etSearch.text.toString())
         }
 
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/search/SearchViewModel.kt
@@ -17,14 +17,6 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(private val departureSearchRepository: DepartureSearchRepository) :
     ViewModel() {
 
-    private val _searchKeyword = MutableLiveData<String>()
-    val searchKeyword: LiveData<String> get() = _searchKeyword
-
-    fun getSearchKeyword(s: CharSequence, start: Int, before: Int, count: Int) {
-        _searchKeyword.value = s.toString()
-        Timber.tag(ContentValues.TAG).d("EditText값 : ${_searchKeyword.value}")
-    }
-
     val searchError = MutableLiveData<String>()
 
     val dataList = MutableLiveData<List<SearchResultEntity>?>()

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -44,7 +44,6 @@
             android:hint="@string/search_set_departure_hint"
             android:imeOptions="actionSearch"
             android:inputType="text"
-            android:onTextChanged="@{model::getSearchKeyword}"
             android:textColor="@color/G1"
             android:textColorHint="@color/G3"
             android:textSize="15sp"


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
closed #251 [DEL] 불필요한 onTextChanged 관련 코드 제거

editText에 입력값이 잘 들어가는지 모니터링 목적으로 xml에 onTextChanged를 달아놨는데 현시점에서는 binding.etSearch.text.toString()으로 값을 받아와 통신 함수 인자에 넣어주는 만큼 불필요해졌다 판단하여 제거합니다.
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- xml 상에서 불필요하게 searchViewModel의 리소스를 참조하고 있던 것을 제거
- 뷰모델 searchKeyword 변수 제거
- 통신 함수에 인자로 전달하는 값을 binding.etSearch.text.toString()으로 대체
## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->

## 📸 스크린샷/동영상
<!--스크린샷을 첨부해주세요 불필요한 경우 생략 가능합니다-->
