### PR TITLE
[REFACTOR] 마이페이지 러닝기록 상세페이지 / 액티비티의 전역변수를 뷰모델로 이전

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/history/detail/MyHistoryDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/history/detail/MyHistoryDetailActivity.kt
@@ -29,8 +29,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class MyHistoryDetailActivity :
     BindingActivity<ActivityMyHistoryDetailBinding>(R.layout.activity_my_history_detail) {
     private val viewModel: MyHistoryDetailViewModel by viewModels()
-    private var currentScreenMode: ScreenMode = ScreenMode.ReadOnlyMode
-    private var temporarilySavedTitle: String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -62,29 +60,21 @@ class MyHistoryDetailActivity :
     }
 
     private fun enterReadMode() {
-        updateCurrentScreenMode(ScreenMode.ReadOnlyMode)
+        viewModel.updateCurrentScreenMode(ScreenMode.ReadOnlyMode)
         updateTitleInputType()
         updateMoreButtonVisibility(true)
         updateConstraintForReadMode()
     }
 
     private fun enterEditMode() {
-        updateCurrentScreenMode(ScreenMode.EditMode)
+        viewModel.updateCurrentScreenMode(ScreenMode.EditMode)
         updateTitleInputType()
         updateMoreButtonVisibility(false)
         updateConstraintForEditMode()
 
         // 중간에 수정을 취소하면 원래 제목으로 되돌리기 위해
-        // 현재 제목을 전역 변수에 저장해둔다.
-        saveTemporarilyCurrentTitle()
-    }
-
-    private fun saveTemporarilyCurrentTitle() {
-        temporarilySavedTitle = viewModel.title
-    }
-
-    private fun updateCurrentScreenMode(mode: ScreenMode) {
-        currentScreenMode = mode
+        // 현재 제목을 뷰모델에 저장해둔다.
+        viewModel.saveCurrentTitle()
     }
 
     private fun updateMoreButtonVisibility(isVisible: Boolean) {
@@ -115,7 +105,7 @@ class MyHistoryDetailActivity :
     }
 
     private fun handleBackButtonByCurrentScreenMode() {
-        when (currentScreenMode) {
+        when (viewModel.currentScreenMode) {
             is ScreenMode.ReadOnlyMode -> navigateToPreviousScreen()
             is ScreenMode.EditMode -> showStopEditingDialog()
         }
@@ -251,7 +241,7 @@ class MyHistoryDetailActivity :
     }
 
     private fun updateTitleInputType() {
-        when (currentScreenMode) {
+        when (viewModel.currentScreenMode) {
             is ScreenMode.ReadOnlyMode -> {
                 binding.etCourseTitle.inputType = InputType.TYPE_NULL
             }
@@ -284,7 +274,7 @@ class MyHistoryDetailActivity :
             onNegativeButtonClicked = {},
             onPositiveButtonClicked = {
                 // 편집 모드 -> 뒤로가기 버튼 -> 편집 중단 확인 -> 뷰에 원래 제목으로 보여줌.
-                viewModel.updateHistoryTitle(temporarilySavedTitle)
+                viewModel.restoreOriginalTitle()
                 enterReadMode()
             }
         )

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/history/detail/MyHistoryDetailViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/history/detail/MyHistoryDetailViewModel.kt
@@ -34,6 +34,10 @@ class MyHistoryDetailViewModel @Inject constructor(private val userRepository: U
 
     val isValidTitle: LiveData<Boolean> = _title.map { it.isNotBlank() }
 
+    private var _currentScreenMode: ScreenMode = ScreenMode.ReadOnlyMode
+    val currentScreenMode get() = _currentScreenMode
+
+    private var savedTitle: String = ""
     private var historyId: Int = -1
 
     fun updateHistoryTitle(title: String) {
@@ -42,6 +46,18 @@ class MyHistoryDetailViewModel @Inject constructor(private val userRepository: U
 
     fun updateHistoryId(id: Int) {
         historyId = id
+    }
+
+    fun saveCurrentTitle() {
+        savedTitle = title
+    }
+
+    fun restoreOriginalTitle() {
+        _title.value = savedTitle
+    }
+
+    fun updateCurrentScreenMode(mode: ScreenMode) {
+        _currentScreenMode = mode
     }
 
     fun deleteHistory() {


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- closed #268

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 이슈 내용 참고 부탁드립니다! 

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
뷰모델을 이용해서 액티비티 생명주기와 무관하게 데이터들을 저장할 수 있다는 건 좋은데,
그에 따라 뷰모델에 getter, setter 관련 코드량이 증가한 것은 그닥 좋은 거 같지 않습니다..! 
더 나은 방법이 있을까요?! 
