### PR TITLE
[REFACTOR] 출발지 모드 세팅 / SearchResultEntity에서 mode 제거 및 리팩토링

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/dto/SearchResultEntity.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/SearchResultEntity.kt
@@ -9,5 +9,4 @@ data class SearchResultEntity(
     val fullAddress: String,
     val name: String,
     val locationLatLng: LatLng?,
-    val mode: String
 ) : Parcelable

--- a/app/src/main/java/com/runnect/runnect/presentation/draw/DrawActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/draw/DrawActivity.kt
@@ -43,9 +43,10 @@ import com.runnect.runnect.databinding.BottomsheetRequireCourseNameBinding
 import com.runnect.runnect.presentation.MainActivity
 import com.runnect.runnect.presentation.countdown.CountDownActivity
 import com.runnect.runnect.presentation.login.LoginActivity
+import com.runnect.runnect.presentation.search.SearchActivity.Companion.EXTRA_DEPARTURE_SET_MODE
 import com.runnect.runnect.presentation.state.UiState
-import com.runnect.runnect.util.multipart.ContentUriRequestBody
 import com.runnect.runnect.util.extension.setActivityDialog
+import com.runnect.runnect.util.multipart.ContentUriRequestBody
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.android.synthetic.main.custom_dialog_make_course.view.btn_run
 import kotlinx.android.synthetic.main.custom_dialog_make_course.view.btn_storage
@@ -77,6 +78,7 @@ class DrawActivity :
     private lateinit var animDown: Animation
     private lateinit var animUp: Animation
     private lateinit var searchResult: SearchResultEntity
+    private lateinit var departureSetMode: String
     private lateinit var captureUri: Uri
 
     private val coords = mutableListOf<LatLng>()
@@ -108,7 +110,10 @@ class DrawActivity :
 
     private fun getSearchIntent() {
         searchResult =
-            intent.getParcelableExtra(EXTRA_SEARCH_RESULT) ?: throw Exception("데이터가 존재하지 않습니다.")
+            intent.getParcelableExtra(EXTRA_SEARCH_RESULT)
+                ?: throw Exception("unknown-search-result")
+        departureSetMode = intent.getStringExtra(EXTRA_DEPARTURE_SET_MODE)
+            ?: throw Exception("unknown-departure-set-mode")
     }
 
     private fun initMapView() {
@@ -135,17 +140,19 @@ class DrawActivity :
         setLocationChangedListener()
         setCameraFinishedListener()
     }
+
     private fun initMode() {
-        when (searchResult.mode) {
+        when (departureSetMode) {
             "searchLocation" -> initSearchLocationMode()
             "currentLocation" -> initCurrentLocationMode()
             "customLocation" -> initCustomLocationMode()
         }
     }
+
     private fun initSearchLocationMode() {
         isSearchLocationMode = true
 
-        with(binding){
+        with(binding) {
             tvGuide.isVisible = false
             btnDraw.text = CREATE_COURSE
         }
@@ -168,6 +175,7 @@ class DrawActivity :
             }
         }
     }
+
     private fun initCurrentLocationMode() {
         isCurrentLocationMode = true
         isMarkerAvailable = true
@@ -180,6 +188,7 @@ class DrawActivity :
         hideDeparture()
         showDrawCourse()
     }
+
     private fun initCustomLocationMode() {
         isCustomLocationMode = true
 
@@ -245,6 +254,7 @@ class DrawActivity :
         val cameraPosition = naverMap.cameraPosition
         return cameraPosition.target // 중심 좌표
     }
+
     private fun setLocationChangedListener() {
         naverMap.addOnLocationChangeListener { location ->
             currentLocation = LatLng(location.latitude, location.longitude)
@@ -256,7 +266,7 @@ class DrawActivity :
             //같은 scope 안에 넣었으니 setDepartureLatLng 다음에 drawCourse가 실행되는 것이 보장됨
             //이때 isFirstInit의 초기값을 true로 줘서 최초 1회는 실행되게 하고 이후 drawCourse 내에서 isFirstInit 값을 false로 바꿔줌
             //뒤의 조건을 안 달아주면 다른 mode에서는 버튼을 클릭하기도 전에 drawCourse()가 돌 거라 안 됨.
-            if(isFirstInit && isCurrentLocationMode){
+            if (isFirstInit && isCurrentLocationMode) {
                 drawCourse(departureLatLng = departureLatLng)
             }
         }

--- a/app/src/main/java/com/runnect/runnect/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/search/SearchActivity.kt
@@ -178,40 +178,28 @@ class SearchActivity :
         }
     }
 
-    override fun startSearchLocation(item: SearchResultEntity) {
+    private fun setDeparture(mode: String, item: SearchResultEntity) {
         startActivity(
             Intent(this, DrawActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
                 putExtra(EXTRA_SEARCH_RESULT, item)
-                putExtra(EXTRA_DEPARTURE_SET_MODE, "searchLocation")
+                putExtra(EXTRA_DEPARTURE_SET_MODE, mode)
             }
         )
+    }
+
+    override fun startSearchLocation(item: SearchResultEntity) {
+        setDeparture("searchLocation", item)
     }
 
     private fun startCurrentLocation() {
-        startActivity(
-            Intent(this, DrawActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
-                putExtra(
-                    EXTRA_SEARCH_RESULT,
-                    SearchResultEntity(fullAddress = "", name = "", locationLatLng = null)
-                )
-                putExtra(EXTRA_DEPARTURE_SET_MODE, "currentLocation")
-            }
-        )
+        val emptyItem = SearchResultEntity(fullAddress = "", name = "", locationLatLng = null)
+        setDeparture("currentLocation", emptyItem)
     }
 
     private fun startCustomLocation() {
-        startActivity(
-            Intent(this, DrawActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
-                putExtra(
-                    EXTRA_SEARCH_RESULT,
-                    SearchResultEntity(fullAddress = "", name = "", locationLatLng = null)
-                )
-                putExtra(EXTRA_DEPARTURE_SET_MODE, "customLocation")
-            }
-        )
+        val emptyItem = SearchResultEntity(fullAddress = "", name = "", locationLatLng = null)
+        setDeparture("customLocation", emptyItem)
     }
 
     //키보드 밖 터치 시, 키보드 내림

--- a/app/src/main/java/com/runnect/runnect/presentation/search/SearchActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/search/SearchActivity.kt
@@ -81,15 +81,6 @@ class SearchActivity :
         binding.recyclerViewSearch.adapter = searchAdapter
     }
 
-    override fun selectItem(item: SearchResultEntity) {
-        startActivity(
-            Intent(this, DrawActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
-                putExtra(EXTRA_SEARCH_RESULT, item) //mode == "searchLocation"
-            }
-        )
-    }
-
     private fun showEmptyView() {
         with(binding) {
             ivNoSearchResult.isVisible = true
@@ -187,26 +178,38 @@ class SearchActivity :
         }
     }
 
-    fun startCurrentLocation() {
+    override fun startSearchLocation(item: SearchResultEntity) {
         startActivity(
             Intent(this, DrawActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
-                putExtra(
-                    EXTRA_SEARCH_RESULT,
-                    SearchResultEntity(fullAddress = "", name = "", locationLatLng = null, mode = "currentLocation")
-                )
+                putExtra(EXTRA_SEARCH_RESULT, item)
+                putExtra(EXTRA_DEPARTURE_SET_MODE, "searchLocation")
             }
         )
     }
 
-    fun startCustomLocation() {
+    private fun startCurrentLocation() {
         startActivity(
             Intent(this, DrawActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
                 putExtra(
                     EXTRA_SEARCH_RESULT,
-                    SearchResultEntity(fullAddress = "", name = "", locationLatLng = null, mode = "customLocation")
+                    SearchResultEntity(fullAddress = "", name = "", locationLatLng = null)
                 )
+                putExtra(EXTRA_DEPARTURE_SET_MODE, "currentLocation")
+            }
+        )
+    }
+
+    private fun startCustomLocation() {
+        startActivity(
+            Intent(this, DrawActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+                putExtra(
+                    EXTRA_SEARCH_RESULT,
+                    SearchResultEntity(fullAddress = "", name = "", locationLatLng = null)
+                )
+                putExtra(EXTRA_DEPARTURE_SET_MODE, "customLocation")
             }
         )
     }
@@ -228,6 +231,7 @@ class SearchActivity :
 
     companion object {
         const val EXTRA_SEARCH_RESULT = "searchResult"
+        const val EXTRA_DEPARTURE_SET_MODE = "departureSetMode"
     }
 
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/search/adapter/SearchAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/search/adapter/SearchAdapter.kt
@@ -18,11 +18,9 @@ class SearchAdapter(private val searchClickListener: OnSearchClick) :
 
         fun bindData(data: SearchResultEntity) {
             binding.searchResultEntity = data
-        } //여기도 dto 구독해서 ui 바인딩 하는 목적이라 낭비임.
 
-        fun bindViews(data: SearchResultEntity) {
             binding.root.setOnClickListener {
-                searchClickListener.selectItem(data) //data는 넣었고 구체적인 동작은 오버라이드할 때
+                searchClickListener.startSearchLocation(data)
             }
         }
 
@@ -35,7 +33,6 @@ class SearchAdapter(private val searchClickListener: OnSearchClick) :
 
     override fun onBindViewHolder(holder: SearchResultItemViewHolder, position: Int) {
         holder.bindData(currentList[position])
-        holder.bindViews(currentList[position])
     }
 
     class Differ : DiffUtil.ItemCallback<SearchResultEntity>() {

--- a/app/src/main/java/com/runnect/runnect/util/callback/OnSearchClick.kt
+++ b/app/src/main/java/com/runnect/runnect/util/callback/OnSearchClick.kt
@@ -3,5 +3,5 @@ package com.runnect.runnect.util.callback
 import com.runnect.runnect.data.dto.SearchResultEntity
 
 interface OnSearchClick {
-    fun selectItem(item: SearchResultEntity)
+    fun startSearchLocation(item: SearchResultEntity)
 }


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
closed #258 

매직 리터럴은 #272 PR merge 후 Enum Class를 활용하여 제거해줄 예정입니다!
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- SearchResultEntity라는 이름으로 mode가 묶여서 하나로 관리되는 게 부적절하다는 판단이 들어서 제거해주었고 putExtra에 서로 다른 key 값으로 넘기는 방향으로 수정
- startActivtiy 관련 중복 코드 제거

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- data class 이름 지을 때 어떤 분들은 Dto로, 어떤 분들은 Entity라는 이름을 다시는데 어떤 경우에 이렇게 이름을 구분 짓는지 아시나요?! (몰라서 물어보는 것)

## 📸 스크린샷/동영상
<!--스크린샷을 첨부해주세요 불필요한 경우 생략 가능합니다-->
