### PR TITLE
[FIX] setOnlyAlertOnce 추가를 통한 소리/진동 제한

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/run/RunActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/run/RunActivity.kt
@@ -35,6 +35,7 @@ import com.runnect.runnect.data.dto.TimerData
 import com.runnect.runnect.databinding.ActivityRunBinding
 import com.runnect.runnect.presentation.endrun.EndRunActivity
 import com.runnect.runnect.presentation.run.TimerService.Companion.EXTRA_TIMER_VALUE
+import com.runnect.runnect.presentation.run.TimerService.Companion.TIMER_UPDATE_ACTION
 import com.runnect.runnect.util.extension.round
 
 class RunActivity :
@@ -124,7 +125,7 @@ class RunActivity :
     override fun onStart() {
         super.onStart()
         // Timer 결과값을 받기 위해 브로드캐스트 리시버 등록
-        registerReceiver(timerReceiver, IntentFilter(TimerService.TIMER_UPDATE_ACTION))
+        registerReceiver(timerReceiver, IntentFilter(TIMER_UPDATE_ACTION))
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/runnect/runnect/presentation/run/TimerService.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/run/TimerService.kt
@@ -39,6 +39,16 @@ class TimerService : Service() {
         return START_STICKY
     }
 
+    fun notifyStartRun() {
+        if (player == null) {
+            player = MediaPlayer.create(this@TimerService, R.raw.start_run)
+            player?.setOnCompletionListener { mediaPlayer ->
+                mediaPlayer.release() // 재생이 끝나면 MediaPlayer 객체를 해제합니다.
+            }
+        }
+        player?.start()
+    }
+
     fun startTimer() {
         timer = Timer()
         timer?.scheduleAtFixedRate(object : TimerTask() {
@@ -86,6 +96,7 @@ class TimerService : Service() {
             .setColor(ContextCompat.getColor(this@TimerService, R.color.M1))
             .setContentTitle("러닝")
             .setContentText("00:00:00")
+            .setOnlyAlertOnce(true)
             .setOngoing(true) // true 일 경우 알림 리스트에서 클릭하거나 좌우로 드래그해도 사라지지 않음
 
         val notificationIntent = Intent(this@TimerService, RunActivity::class.java)
@@ -117,16 +128,6 @@ class TimerService : Service() {
         ) // id : 정의해야하는 각 알림의 고유한 int값
         val notification = notificationBuilder.build()
         startForeground(NOTI_ID, notification)
-    }
-
-    fun notifyStartRun() {
-        if (player == null) {
-            player = MediaPlayer.create(this@TimerService, R.raw.start_run)
-            player?.setOnCompletionListener { mediaPlayer ->
-                mediaPlayer.release() // 재생이 끝나면 MediaPlayer 객체를 해제합니다.
-            }
-        }
-        player?.start()
     }
 
     companion object {


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
closed #273
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- setOnlyAlertOnce(true) 추가를 통해 소리/진동 최초 1회로 제한
- 가독성을 위해 Service 파일 내 함수 배치 조정
## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
- 당시 service 활용이 처음이라 정확히 알고 개발한 feature가 아니어서 코드적으로 불필요하거나 허술한 부분이 있을 수 있습니다. 혹시 그런 부분이 보인다면 피드백 부탁드립니다! 이 branch로 checkout해서 안드로이드 스튜디오에서 봐주시면 감사하겠습니다! (즉, **service를 잘 활용한 것이 맞는지**)
- 실 기기로 빌드 돌려서 어떤 문제(1초마다 시스템 알림소리/진동이 계속 울림)였는지 확인 후 지금 pr 올린 branch로 checkout해서 **문제가 잘 해결되었는지 테스트** 부탁드립니다!
- 공식 문서를 참고하여 당장 눈에 보이는 문제는 해결하긴 했는데 아래 스크린샷 보시면 매초마다 NotificationManager 로그가 계속 찍혀나옵니다. 원래 이게 당연한 건지, 아니면 제가 뭘 잘못해놔서 **불필요하게 리소스가 낭비**(ex. 함수나 객체 계속 호출)되고 있는지  잘 모르겠습니다. 혹시 이 부분 관련하여 피드백 받아볼 수 있으면 부탁드립니다!
![image](https://github.com/Runnect/Runnect-Android/assets/151606926/269ed535-caa6-4162-8a01-116875d34244)

https://developer.android.com/training/notify-user/build-notification?hl=ko#Updating

## 📸 스크린샷/동영상
<!--스크린샷을 첨부해주세요 불필요한 경우 생략 가능합니다-->
![타이머 문제](https://github.com/Runnect/Runnect-Android/assets/151606926/6483ec2a-9dc9-475c-87a1-efad937c8ec8)