### PR TITLE
[FEAT] 코스 생성 api 수정 사항 반영 및 버그 대응

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponsePostMyDrawCourse.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponsePostMyDrawCourse.kt
@@ -5,20 +5,20 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ResponsePostMyDrawCourse(
-    @SerialName("data")
-    val data: Data,
-    @SerialName("message")
-    val message: String,
     @SerialName("status")
     val status: Int,
     @SerialName("success")
     val success: Boolean,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: Data,
 ) {
     @Serializable
     data class Data(
-        @SerialName("createdAt")
-        val createdAt: String,
         @SerialName("id")
         val id: Int,
+        @SerialName("createdAt")
+        val createdAt: String,
     )
 }

--- a/app/src/main/java/com/runnect/runnect/data/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/com/runnect/runnect/data/repository/CourseRepositoryImpl.kt
@@ -67,11 +67,11 @@ class CourseRepositoryImpl @Inject constructor(private val remoteCourseDataSourc
 
     override suspend fun uploadCourse(
         image: MultipartBody.Part,
-        courseCreateRequestDto: RequestBody
+        data: RequestBody
     ): Response<ResponsePostMyDrawCourse> {
         return remoteCourseDataSource.uploadCourse(
             image = image,
-            courseCreateRequestDto = courseCreateRequestDto
+            data = data
         )
     }
 

--- a/app/src/main/java/com/runnect/runnect/data/service/CourseService.kt
+++ b/app/src/main/java/com/runnect/runnect/data/service/CourseService.kt
@@ -83,9 +83,9 @@ interface CourseService {
 
     //코스 업로드
     @Multipart
-    @POST("/api/course/v2")
+    @POST("/api/course")
     suspend fun uploadCourse(
         @Part image: MultipartBody.Part,
-        @Part("courseCreateRequestDto") courseCreateRequestDto: RequestBody,
+        @Part("data") data: RequestBody,
     ): Response<ResponsePostMyDrawCourse>
 }

--- a/app/src/main/java/com/runnect/runnect/data/source/remote/RemoteCourseDataSource.kt
+++ b/app/src/main/java/com/runnect/runnect/data/source/remote/RemoteCourseDataSource.kt
@@ -53,6 +53,6 @@ class RemoteCourseDataSource @Inject constructor(
 
     suspend fun postRecord(request: RequestPostRunningHistory) = courseService.postRecord(request)
 
-    suspend fun uploadCourse(image: MultipartBody.Part, courseCreateRequestDto: RequestBody) =
-        courseService.uploadCourse(image, courseCreateRequestDto)
+    suspend fun uploadCourse(image: MultipartBody.Part, data: RequestBody) =
+        courseService.uploadCourse(image, data)
 }

--- a/app/src/main/java/com/runnect/runnect/domain/repository/CourseRepository.kt
+++ b/app/src/main/java/com/runnect/runnect/domain/repository/CourseRepository.kt
@@ -37,7 +37,7 @@ interface CourseRepository {
     suspend fun postRecord(request: RequestPostRunningHistory): Response<ResponsePostMyHistory>
 
     suspend fun uploadCourse(
-        image: MultipartBody.Part, courseCreateRequestDto: RequestBody
+        image: MultipartBody.Part, data: RequestBody
     ): Response<ResponsePostMyDrawCourse>
     suspend fun getCourseDetail(publicCourseId: Int): Result<CourseDetail?>
 

--- a/app/src/main/java/com/runnect/runnect/presentation/draw/DrawActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/draw/DrawActivity.kt
@@ -203,7 +203,9 @@ class DrawActivity : BindingActivity<ActivityDrawBinding>(R.layout.activity_draw
                 showDrawCourse()
                 customDepartureLatLng = getCenterPosition()
                 isBlockUpdateDeparture = true
-                drawCourse(departureLatLng = customDepartureLatLng)
+                getCenterPosition().apply {
+                    departureLatLng = this
+                }.let(::drawCourse)
 
                 //커스텀 모드 시 departureLatLng이 계속 현위치 좌표값으로 갱신되어 RunActivity로 path 넘길 때 잘못된 값이 넘어가서 대응 조치
                 //위의 방법으로도 한계가 있어서 putExtra 직전에 값을 한 번 더 갱신해주는 식으로 대응

--- a/app/src/main/java/com/runnect/runnect/presentation/draw/DrawViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/draw/DrawViewModel.kt
@@ -24,8 +24,6 @@ class DrawViewModel @Inject constructor(
     val reverseGeocodingRepository: ReverseGeocodingRepository
 ) : ViewModel() {
 
-    val editTextValue = MutableLiveData<String>()
-
     private var _drawState = MutableLiveData<UiState>(UiState.Empty)
     val drawState: LiveData<UiState>
         get() = _drawState
@@ -36,7 +34,7 @@ class DrawViewModel @Inject constructor(
     var distanceSum = MutableLiveData(0.0f)
     val departureAddress = MutableLiveData<String>()
     var courseTitle = ""
-    val departureName = MutableLiveData<String>()
+    val departureName = MutableLiveData("내가 설정한 출발지")
     val isBtnAvailable = MutableLiveData(false)
 
     val reverseGeocodingResult = MutableLiveData<LocationData>()
@@ -100,7 +98,7 @@ class DrawViewModel @Inject constructor(
                         ),
                         title = courseTitle,
                         distance = distanceSum.value!!,
-                        departureAddress = departureAddress.value!!, //커스텀의 경우 지금 여기에 들어가는 게 아무것도 없음.
+                        departureAddress = departureAddress.value!!,
                         departureName = departureName.value!!
                     ).toRequestBody()
                 )

--- a/app/src/main/java/com/runnect/runnect/presentation/draw/DrawViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/draw/DrawViewModel.kt
@@ -91,7 +91,7 @@ class DrawViewModel @Inject constructor(
                 _drawState.value = UiState.Loading
                 courseRepository.uploadCourse(
                     image = _image.value!!.toFormData(),
-                    courseCreateRequestDto = CourseCreateRequestDto(
+                    data = CourseCreateRequestDto(
                         path = path.value ?: listOf(
                             UploadLatLng(
                                 37.52901832956373,
@@ -105,6 +105,10 @@ class DrawViewModel @Inject constructor(
                     ).toRequestBody()
                 )
             }.onSuccess {
+                if (it.body() == null) {
+                    _drawState.value = UiState.Failure
+                    return@onSuccess //추가 조치 필요
+                }
                 Timber.tag(ContentValues.TAG).d("통신success")
                 uploadResult.value = it.body()
                 _drawState.value = UiState.Success


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->
- Closed #306 
## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->
- 코스 생성 api 수정 사항 반영 
    - requestBody 및 response 수정 
    - 출발지 설정 3개 mode에 대해 각각에 필요한 형태로 requestBody 및 putExtra 세팅 
- 버그 대응
    - 커스텀 출발지 지정 : CountDownActivity로 data를 넘길 때 departureLatLng이 사용자가 지정한 출발지가 아닌 현위치 좌표값이 넘어가는 이슈
    
 커스텀 출발지에서 사용자가 출발지를 직접 지정한 후에도(더이상 현위치 좌표값이 필요없는 상황에서도) addOnLocationChangeListener가 자동으로 계속 돌아서 departureLatLng을 현위치로 갱신시키는 바람에 
 
 그러지 못하도록 isBlockUpdateDeparture라는 변수를 선언해서 사용자가 출발지를 직접 지정한 후에는 departureLatLng이 addOnLocationChangeListener에 의해 갱신이 못되도록 막아주었습니다.

 그런데 (정확한 원인 파악은 못했지만 아마도) addOnLocationChangeListener는 실행 타이밍이 불규칙하다보니 제가 한 조치로는 온전히 막을 수 없는 것 같아 
 
 사용자가 출발지를 직접 지정하는 시점에 customDepartureLatLng라는 변수를 따로 두어 putExtra 시점에 departureLatLng 값을 customDepartureLatLng으로 갱신시키는 방법으로 막았습니다.
 
 문제 해결은 어찌저찌 했지만 코드가 깔끔하지 못하고 지저분해진다는 느낌에 아쉬움이 남습니다.

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->
이번에 2차 업데이트(출발지 설정할 수 있는 옵션 추가) feature 개발할 때
파일 여러개 만들기보단 기존에 짜놨던 하나의 파일(DrawActivity) 안에서 분기 처리를 통해 재사용하려고 했던 건데

이렇게 하다보니 3개 mode(장소 검색/현위치/직접 지정) 각각이 취해줘야 할 상황이 다른데 같은 변수와 함수를 공유하다보니 분기 처리가 매우 까다로웠고 (함수도 지저분해지고) 어느 하나를 건드렸을 때 기존에 잘 동작하던 다른 mode들에 사이드 이펙트가 생기진 않을지 걱정하면서 코드를 짜야했습니다. 

추후 리팩토링을 무조건 해야겠다고 느꼈는데 파일이 여러개 생기더라도 3개 mode 각각에 대해 Activity를 만들어 쓰는 방향으로 생각중입니다. 

**지금처럼 한 파일 안에 분기 처리를 하는 방향을 유지하되 조금 더 다듬어볼지, 아니면 Activity를 나눌지 리팩토링 방향에 대한 의견과 근거가 궁금합니다.**
