### PR TITLE
[FEAT] 코스 발견 / 추천 코스 정렬 기능 

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/repository/CourseRepositoryImpl.kt
+++ b/app/src/main/java/com/runnect/runnect/data/repository/CourseRepositoryImpl.kt
@@ -33,11 +33,11 @@ class CourseRepositoryImpl @Inject constructor(private val remoteCourseDataSourc
 
     override suspend fun getRecommendCourse(
         pageNo: String,
-        ordering: String
+        sort: String
     ): Result<RecommendCoursePagingData?> = runCatching {
         val response = remoteCourseDataSource.getRecommendCourse(
             pageNo = pageNo,
-            ordering = ordering
+            sort = sort
         ).data
 
         response?.let {

--- a/app/src/main/java/com/runnect/runnect/data/service/CourseService.kt
+++ b/app/src/main/java/com/runnect/runnect/data/service/CourseService.kt
@@ -19,7 +19,7 @@ interface CourseService {
     @GET("/api/public-course")
     suspend fun getRecommendCourse(
         @Query("pageNo") pageNo: String,
-        @Query("ordering") ordering: String
+        @Query("sort") sort: String
     ): BaseResponse<ResponseGetDiscoverRecommend>
 
     @POST("/api/scrap")

--- a/app/src/main/java/com/runnect/runnect/data/source/remote/RemoteCourseDataSource.kt
+++ b/app/src/main/java/com/runnect/runnect/data/source/remote/RemoteCourseDataSource.kt
@@ -24,9 +24,9 @@ class RemoteCourseDataSource @Inject constructor(
 
     suspend fun getRecommendCourse(
         pageNo: String,
-        ordering: String
+        sort: String
     ): BaseResponse<ResponseGetDiscoverRecommend> =
-        courseService.getRecommendCourse(pageNo = pageNo, ordering = ordering)
+        courseService.getRecommendCourse(pageNo = pageNo, sort = sort)
 
     suspend fun postCourseScrap(requestPostCourseScrap: RequestPostCourseScrap): BaseResponse<ResponsePostScrap> =
         courseService.postCourseScrap(requestPostCourseScrap)

--- a/app/src/main/java/com/runnect/runnect/domain/repository/CourseRepository.kt
+++ b/app/src/main/java/com/runnect/runnect/domain/repository/CourseRepository.kt
@@ -26,7 +26,7 @@ interface CourseRepository {
 
     suspend fun getRecommendCourse(
         pageNo: String,
-        ordering: String
+        sort: String
     ): Result<RecommendCoursePagingData?>
 
     suspend fun getCourseSearch(keyword: String): Result<List<DiscoverSearchCourse>?>

--- a/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
@@ -149,7 +149,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         var storageScrapFragment: StorageScrapFragment? = null
 
         fun updateCourseDiscoverScreen() {
-            discoverFragment?.getRecommendCourses()
+            discoverFragment?.refreshDiscoverCourses()
         }
 
         fun updateStorageScrapScreen() {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -411,7 +411,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
         viewModel.recommendCourseSortState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is UiStateV2.Success -> {
-                    multiViewAdapter.updateRecommendCourseBySorting(state.data)
+                    multiViewAdapter.sortRecommendCourseFirstPage(state.data)
                 }
 
                 is UiStateV2.Failure -> {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -96,6 +96,9 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
             },
             handleVisitorMode = {
                 context?.let { showCourseScrapWarningToast(it) }
+            },
+            onSortButtonClick = { criteria ->
+                viewModel.sortRecommendCourse()
             }
         ).apply {
             binding.rvDiscoverMultiView.adapter = this
@@ -331,7 +334,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     }
 
     private fun setupMarathonCourseGetStateObserver() {
-        viewModel.marathonCourseState.observe(viewLifecycleOwner) { state ->
+        viewModel.marathonCourseGetState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is UiStateV2.Success -> {
                     multiViewAdapter.initMarathonCourses(state.data)
@@ -351,7 +354,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     }
 
     private fun setupRecommendCourseGetStateObserver() {
-        viewModel.recommendCourseState.observe(viewLifecycleOwner) { state ->
+        viewModel.recommendCourseGetState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is UiStateV2.Loading -> showLoadingProgressBar()
 
@@ -385,7 +388,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     }
 
     private fun setupRecommendCourseNextPageStateObserver() {
-        viewModel.nextPageState.observe(viewLifecycleOwner) { state ->
+        viewModel.recommendCourseNextPageState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is UiStateV2.Success -> {
                     multiViewAdapter.addRecommendCourseNextPage(state.data)

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -469,8 +469,8 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
         return layoutManager.findFirstCompletelyVisibleItemPosition() > 0
     }
 
-    fun getRecommendCourses() {
-        viewModel.getRecommendCourses()
+    fun refreshDiscoverCourses() {
+        viewModel.refreshDiscoverCourses()
     }
 
     override fun onAttach(context: Context) {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -141,7 +141,6 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
             ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-                Timber.d("viewpager position: $position")
                 updateBannerPosition(position)
                 updateBannerIndicatorPosition()
             }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -102,7 +102,6 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
             }
         ).apply {
             binding.rvDiscoverMultiView.adapter = this
-            binding.rvDiscoverMultiView.setHasFixedSize(true)
         }
     }
 

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -98,7 +98,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
                 context?.let { showCourseScrapWarningToast(it) }
             },
             onSortButtonClick = { criteria ->
-                viewModel.sortRecommendCourse()
+                viewModel.sortRecommendCourses(criteria)
             }
         ).apply {
             binding.rvDiscoverMultiView.adapter = this

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -17,7 +17,6 @@ import com.runnect.runnect.R
 import com.runnect.runnect.binding.BindingFragment
 import com.runnect.runnect.databinding.FragmentDiscoverBinding
 import com.runnect.runnect.domain.entity.DiscoverBanner
-import com.runnect.runnect.domain.entity.DiscoverMultiViewItem
 import com.runnect.runnect.presentation.discover.model.EditableDiscoverCourse
 import com.runnect.runnect.presentation.MainActivity
 import com.runnect.runnect.presentation.MainActivity.Companion.isVisitorMode
@@ -41,7 +40,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 @AndroidEntryPoint

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -223,9 +223,11 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
 
     private fun initRefreshLayoutListener() {
         binding.refreshLayout.setOnRefreshListener {
+            // 리프레시 직후에 비어있는 리스트로 리사이클러뷰 초기화
             multiViewAdapter.initMarathonCourses(emptyList())
             multiViewAdapter.initRecommendCourses(emptyList())
 
+            // 서버통신 직후에 첫 페이지 데이터로 리사이클러뷰 초기화
             viewModel.refreshDiscoverCourses()
             binding.refreshLayout.isRefreshing = false
         }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -223,6 +223,9 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
 
     private fun initRefreshLayoutListener() {
         binding.refreshLayout.setOnRefreshListener {
+            multiViewAdapter.initMarathonCourses(emptyList())
+            multiViewAdapter.initRecommendCourses(emptyList())
+
             viewModel.refreshDiscoverCourses()
             binding.refreshLayout.isRefreshing = false
         }
@@ -354,8 +357,11 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
                 is UiStateV2.Loading -> showLoadingProgressBar()
 
                 is UiStateV2.Success -> {
-                    dismissLoadingProgressBar()
+                    // todo: 리프레시에 의한 추천코스 어댑터의 submitList 동작이 완료되고 나서
                     multiViewAdapter.initRecommendCourses(state.data)
+
+                    // todo: 로딩 프로그레스바를 삭제해야 한다.
+                    dismissLoadingProgressBar()
                 }
 
                 is UiStateV2.Failure -> {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -274,6 +274,7 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
         setupMarathonCourseGetStateObserver()
         setupRecommendCourseGetStateObserver()
         setupRecommendCourseNextPageStateObserver()
+        setupRecommendCourseSortStateObserver()
         setupCourseScrapStateObserver()
     }
 
@@ -392,6 +393,26 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
             when (state) {
                 is UiStateV2.Success -> {
                     multiViewAdapter.addRecommendCourseNextPage(state.data)
+                }
+
+                is UiStateV2.Failure -> {
+                    context?.showSnackbar(
+                        anchorView = binding.root,
+                        message = state.msg,
+                        gravity = Gravity.TOP
+                    )
+                }
+
+                else -> {}
+            }
+        }
+    }
+
+    private fun setupRecommendCourseSortStateObserver() {
+        viewModel.recommendCourseSortState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is UiStateV2.Success -> {
+                    multiViewAdapter.updateRecommendCourseBySorting(state.data)
                 }
 
                 is UiStateV2.Failure -> {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -40,7 +40,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragment_discover) {
@@ -192,19 +191,15 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
                 val isScrollDown = dy > 0
                 if (isScrollDown) showCircleUploadButton()
 
-                checkNextPageLoadingCondition(recyclerView)
+                if (checkNextPageLoadingCondition(recyclerView)) {
+                    viewModel.getRecommendCourseNextPage()
+                }
             }
         })
     }
 
-    private fun checkNextPageLoadingCondition(recyclerView: RecyclerView) {
-        if (isCourseLoadingCompleted() && !recyclerView.canScrollVertically(SCROLL_DIRECTION)) {
-            Timber.d("스크롤이 끝에 도달했어요!")
-            if (!viewModel.isNextPageLoading()) {
-                viewModel.getRecommendCourseNextPage()
-            }
-        }
-    }
+    private fun checkNextPageLoadingCondition(recyclerView: RecyclerView) =
+        isCourseLoadingCompleted() && !recyclerView.canScrollVertically(SCROLL_DIRECTION) && !viewModel.isNextPageLoading()
 
     private fun isCourseLoadingCompleted() = ::multiViewAdapter.isInitialized &&
             multiViewAdapter.itemCount >= DiscoverMultiViewType.values().size

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -65,13 +65,18 @@ class DiscoverViewModel @Inject constructor(
 
     fun refreshDiscoverCourses() {
         getMarathonCourses()
+
         initRecommendCoursePagingData()
+        initRecommendCourseSortCriteria()
         getRecommendCourses()
     }
 
     private fun initRecommendCoursePagingData() {
         isRecommendCoursePageEnd = false
         currentPageNumber = FIRST_PAGE_NUM
+    }
+
+    private fun initRecommendCourseSortCriteria() {
         currentSortCriteria = DEFAULT_SORT_CRITERIA
     }
 
@@ -111,7 +116,7 @@ class DiscoverViewModel @Inject constructor(
         }
     }
 
-    fun getRecommendCourses() {
+    private fun getRecommendCourses() {
         viewModelScope.launch {
             _recommendCourseGetState.value = UiStateV2.Loading
 
@@ -169,7 +174,7 @@ class DiscoverViewModel @Inject constructor(
 
     fun sortRecommendCourses(criteria: String) {
         initRecommendCoursePagingData()
-        saveCurrentSortCriteria(criteria)
+        updateCurrentSortCriteria(criteria)
 
         viewModelScope.launch {
             _recommendCourseSortState.value = UiStateV2.Loading
@@ -194,7 +199,7 @@ class DiscoverViewModel @Inject constructor(
         }
     }
 
-    private fun saveCurrentSortCriteria(criteria: String) {
+    private fun updateCurrentSortCriteria(criteria: String) {
         currentSortCriteria = criteria
     }
 

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -115,7 +115,7 @@ class DiscoverViewModel @Inject constructor(
 
             courseRepository.getRecommendCourse(
                 pageNo = FIRST_PAGE_NUM.toString(),
-                ordering = DEFAULT_SORT_CRITERIA
+                sort = DEFAULT_SORT_CRITERIA
             ).onSuccess { pagingData ->
                 if (pagingData == null) {
                     _recommendCourseGetState.value =
@@ -145,7 +145,7 @@ class DiscoverViewModel @Inject constructor(
 
             courseRepository.getRecommendCourse(
                 pageNo = currentPageNumber.toString(),
-                ordering = DEFAULT_SORT_CRITERIA
+                sort = DEFAULT_SORT_CRITERIA
             )
                 .onSuccess { pagingData ->
                     if (pagingData == null) {
@@ -171,7 +171,7 @@ class DiscoverViewModel @Inject constructor(
 
             courseRepository.getRecommendCourse(
                 pageNo = FIRST_PAGE_NUM.toString(),
-                ordering = criteria
+                sort = criteria
             ).onSuccess { pagingData ->
                 if (pagingData == null) {
                     _recommendCourseSortState.value =

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -165,8 +165,28 @@ class DiscoverViewModel @Inject constructor(
         }
     }
 
-    fun sortRecommendCourse() {
+    fun sortRecommendCourses(criteria: String) {
+        viewModelScope.launch {
+            _recommendCourseSortState.value = UiStateV2.Loading
 
+            courseRepository.getRecommendCourse(
+                pageNo = FIRST_PAGE_NUM.toString(),
+                ordering = criteria
+            ).onSuccess { pagingData ->
+                if (pagingData == null) {
+                    _recommendCourseSortState.value =
+                        UiStateV2.Failure("RECOMMEND COURSE DATA IS NULL")
+                    return@onSuccess
+                }
+
+                isRecommendCoursePageEnd = pagingData.isEnd
+                _recommendCourseSortState.value = UiStateV2.Success(pagingData.recommendCourses)
+                Timber.d("RECOMMEND COURSE SORT SUCCESS")
+            }.onFailure { exception ->
+                _recommendCourseSortState.value = UiStateV2.Failure(exception.message.toString())
+                Timber.e("RECOMMEND COURSE SORT FAIL")
+            }
+        }
     }
 
     fun postCourseScrap(id: Int, scrapTF: Boolean) {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -144,14 +144,14 @@ class DiscoverViewModel @Inject constructor(
 
     fun getRecommendCourseNextPage() {
         viewModelScope.launch {
+            // 다음 페이지가 없으면 요청하지 않는다.
             if (isRecommendCoursePageEnd) return@launch
 
             Timber.d("다음 페이지를 요청했어요! 정렬 기준: $currentSortCriteria")
             _recommendCourseNextPageState.value = UiStateV2.Loading
-            currentPageNumber++
 
             courseRepository.getRecommendCourse(
-                pageNo = currentPageNumber.toString(),
+                pageNo = (currentPageNumber + 1).toString(),
                 sort = currentSortCriteria
             )
                 .onSuccess { pagingData ->
@@ -161,12 +161,16 @@ class DiscoverViewModel @Inject constructor(
                         return@onSuccess
                     }
 
+                    // 전역변수 업데이트
                     isRecommendCoursePageEnd = pagingData.isEnd
+                    currentPageNumber++
+
                     _recommendCourseNextPageState.value = UiStateV2.Success(pagingData.recommendCourses)
                     Timber.d("RECOMMEND COURSE NEXT PAGE GET SUCCESS")
                 }
                 .onFailure { exception ->
-                    _recommendCourseNextPageState.value = UiStateV2.Failure(exception.message.toString())
+                    _recommendCourseNextPageState.value =
+                        UiStateV2.Failure(exception.message.toString())
                     Timber.e("RECOMMEND COURSE NEXT PAGE GET FAIL")
                 }
         }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -51,6 +51,7 @@ class DiscoverViewModel @Inject constructor(
 
     private var isRecommendCoursePageEnd = false
     private var currentPageNumber = FIRST_PAGE_NUM
+    private var currentSortCriteria = DEFAULT_SORT_CRITERIA
 
     init {
         getDiscoverBanners()
@@ -71,6 +72,7 @@ class DiscoverViewModel @Inject constructor(
     private fun initRecommendCoursePagingData() {
         isRecommendCoursePageEnd = false
         currentPageNumber = FIRST_PAGE_NUM
+        currentSortCriteria = DEFAULT_SORT_CRITERIA
     }
 
     private fun getDiscoverBanners() {
@@ -139,13 +141,13 @@ class DiscoverViewModel @Inject constructor(
         viewModelScope.launch {
             if (isRecommendCoursePageEnd) return@launch
 
-            Timber.d("다음 페이지를 요청했어요!")
+            Timber.d("다음 페이지를 요청했어요! 정렬 기준: $currentSortCriteria")
             _recommendCourseNextPageState.value = UiStateV2.Loading
             currentPageNumber++
 
             courseRepository.getRecommendCourse(
                 pageNo = currentPageNumber.toString(),
-                sort = DEFAULT_SORT_CRITERIA
+                sort = currentSortCriteria
             )
                 .onSuccess { pagingData ->
                     if (pagingData == null) {
@@ -166,6 +168,9 @@ class DiscoverViewModel @Inject constructor(
     }
 
     fun sortRecommendCourses(criteria: String) {
+        initRecommendCoursePagingData()
+        saveCurrentSortCriteria(criteria)
+
         viewModelScope.launch {
             _recommendCourseSortState.value = UiStateV2.Loading
 
@@ -187,6 +192,10 @@ class DiscoverViewModel @Inject constructor(
                 Timber.e("RECOMMEND COURSE SORT FAIL")
             }
         }
+    }
+
+    private fun saveCurrentSortCriteria(criteria: String) {
+        currentSortCriteria = criteria
     }
 
     fun postCourseScrap(id: Int, scrapTF: Boolean) {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -26,17 +26,21 @@ class DiscoverViewModel @Inject constructor(
     val bannerGetState: LiveData<UiStateV2<List<DiscoverBanner>>>
         get() = _bannerGetState
 
-    private val _marathonCourseState = MutableLiveData<UiStateV2<List<MarathonCourse>>>()
-    val marathonCourseState: LiveData<UiStateV2<List<MarathonCourse>>>
-        get() = _marathonCourseState
+    private val _marathonCourseGetState = MutableLiveData<UiStateV2<List<MarathonCourse>>>()
+    val marathonCourseGetState: LiveData<UiStateV2<List<MarathonCourse>>>
+        get() = _marathonCourseGetState
 
-    private val _recommendCourseState = MutableLiveData<UiStateV2<List<RecommendCourse>>>()
-    val recommendCourseState: LiveData<UiStateV2<List<RecommendCourse>>>
-        get() = _recommendCourseState
+    private val _recommendCourseGetState = MutableLiveData<UiStateV2<List<RecommendCourse>>>()
+    val recommendCourseGetState: LiveData<UiStateV2<List<RecommendCourse>>>
+        get() = _recommendCourseGetState
 
-    private val _nextPageState = MutableLiveData<UiStateV2<List<RecommendCourse>>>()
-    val nextPageState: LiveData<UiStateV2<List<RecommendCourse>>>
-        get() = _nextPageState
+    private val _recommendCourseNextPageState = MutableLiveData<UiStateV2<List<RecommendCourse>>>()
+    val recommendCourseNextPageState: LiveData<UiStateV2<List<RecommendCourse>>>
+        get() = _recommendCourseNextPageState
+
+    private val _recommendCourseSortState = MutableLiveData<UiStateV2<List<RecommendCourse>>>()
+    val recommendCourseSortState: LiveData<UiStateV2<List<RecommendCourse>>>
+        get() = _recommendCourseSortState
 
     private val _courseScrapState = MutableLiveData<UiStateV2<ResponsePostScrap?>>()
     val courseScrapState: LiveData<UiStateV2<ResponsePostScrap?>>
@@ -85,21 +89,21 @@ class DiscoverViewModel @Inject constructor(
 
     private fun getMarathonCourses() {
         viewModelScope.launch {
-            _marathonCourseState.value = UiStateV2.Loading
+            _marathonCourseGetState.value = UiStateV2.Loading
 
             courseRepository.getMarathonCourse()
                 .onSuccess { courses ->
                     if (courses == null) {
-                        _marathonCourseState.value =
+                        _marathonCourseGetState.value =
                             UiStateV2.Failure("MARATHON COURSE DATA IS NULL")
                         return@launch
                     }
 
-                    _marathonCourseState.value = UiStateV2.Success(courses)
+                    _marathonCourseGetState.value = UiStateV2.Success(courses)
                     Timber.d("MARATHON COURSE GET SUCCESS")
                 }
                 .onFailure { exception ->
-                    _marathonCourseState.value = UiStateV2.Failure(exception.message.toString())
+                    _marathonCourseGetState.value = UiStateV2.Failure(exception.message.toString())
                     Timber.e("MARATHON COURSE GET FAIL")
                 }
         }
@@ -107,36 +111,36 @@ class DiscoverViewModel @Inject constructor(
 
     fun getRecommendCourses() {
         viewModelScope.launch {
-            _recommendCourseState.value = UiStateV2.Loading
+            _recommendCourseGetState.value = UiStateV2.Loading
 
             courseRepository.getRecommendCourse(
                 pageNo = FIRST_PAGE_NUM.toString(),
                 ordering = DEFAULT_SORT_CRITERIA
             ).onSuccess { pagingData ->
                 if (pagingData == null) {
-                    _recommendCourseState.value =
+                    _recommendCourseGetState.value =
                         UiStateV2.Failure("RECOMMEND COURSE DATA IS NULL")
                     return@onSuccess
                 }
 
                 isRecommendCoursePageEnd = pagingData.isEnd
-                _recommendCourseState.value = UiStateV2.Success(pagingData.recommendCourses)
+                _recommendCourseGetState.value = UiStateV2.Success(pagingData.recommendCourses)
                 Timber.d("RECOMMEND COURSE GET SUCCESS")
             }.onFailure { exception ->
-                _recommendCourseState.value = UiStateV2.Failure(exception.message.toString())
+                _recommendCourseGetState.value = UiStateV2.Failure(exception.message.toString())
                 Timber.e("RECOMMEND COURSE GET FAIL")
             }
         }
     }
 
-    fun isNextPageLoading() = nextPageState.value is UiStateV2.Loading
+    fun isNextPageLoading() = recommendCourseNextPageState.value is UiStateV2.Loading
 
     fun getRecommendCourseNextPage() {
         viewModelScope.launch {
             if (isRecommendCoursePageEnd) return@launch
 
             Timber.d("다음 페이지를 요청했어요!")
-            _nextPageState.value = UiStateV2.Loading
+            _recommendCourseNextPageState.value = UiStateV2.Loading
             currentPageNumber++
 
             courseRepository.getRecommendCourse(
@@ -145,20 +149,24 @@ class DiscoverViewModel @Inject constructor(
             )
                 .onSuccess { pagingData ->
                     if (pagingData == null) {
-                        _nextPageState.value =
+                        _recommendCourseNextPageState.value =
                             UiStateV2.Failure("RECOMMEND COURSE NEXT PAGE DATA IS NULL")
                         return@onSuccess
                     }
 
                     isRecommendCoursePageEnd = pagingData.isEnd
-                    _nextPageState.value = UiStateV2.Success(pagingData.recommendCourses)
+                    _recommendCourseNextPageState.value = UiStateV2.Success(pagingData.recommendCourses)
                     Timber.d("RECOMMEND COURSE NEXT PAGE GET SUCCESS")
                 }
                 .onFailure { exception ->
-                    _nextPageState.value = UiStateV2.Failure(exception.message.toString())
+                    _recommendCourseNextPageState.value = UiStateV2.Failure(exception.message.toString())
                     Timber.e("RECOMMEND COURSE NEXT PAGE GET FAIL")
                 }
         }
+    }
+
+    fun sortRecommendCourse() {
+
     }
 
     fun postCourseScrap(id: Int, scrapTF: Boolean) {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverViewModel.kt
@@ -132,13 +132,13 @@ class DiscoverViewModel @Inject constructor(
                     return@onSuccess
                 }
 
-                _recommendCourseGetState.value = UiStateV2.Success(pagingData.recommendCourses)
-                Timber.d("RECOMMEND COURSE GET SUCCESS")
-
                 updateRecommendCoursePagingData(
                     isEnd = pagingData.isEnd,
                     pageNo = FIRST_PAGE_NUM
                 )
+
+                _recommendCourseGetState.value = UiStateV2.Success(pagingData.recommendCourses)
+                Timber.d("RECOMMEND COURSE GET SUCCESS")
 
             }.onFailure { exception ->
                 _recommendCourseGetState.value = UiStateV2.Failure(exception.message.toString())

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverMarathonAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverMarathonAdapter.kt
@@ -78,14 +78,17 @@ class DiscoverMarathonAdapter(
     }
 
     fun updateMarathonCourseItem(
-        targetIndex: Int,
+        publicCourseId: Int,
         updatedCourse: EditableDiscoverCourse
     ) {
-        currentList[targetIndex].apply {
-            title = updatedCourse.title
-            scrap = updatedCourse.scrap
+        currentList.forEachIndexed { index, course ->
+            if (course.id == publicCourseId) {
+                course.title = updatedCourse.title
+                course.scrap = updatedCourse.scrap
+                notifyItemChanged(index)
+                return
+            }
         }
-        notifyItemChanged(targetIndex)
     }
 
     companion object {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
@@ -90,8 +90,7 @@ class DiscoverRecommendAdapter(
     }
 
     fun addRecommendCourseNextPage(items: List<DiscoverMultiViewItem.RecommendCourse>) {
-        val newList = currentList.toMutableList()
-        newList.addAll(items)
+        val newList = currentList + items
         submitList(newList)
     }
 

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
@@ -89,14 +89,14 @@ class DiscoverRecommendAdapter(
         notifyItemChanged(targetIndex)
     }
 
-    fun addRecommendCourseNextPage(items: List<DiscoverMultiViewItem.RecommendCourse>) {
-        notifyItemRangeInserted(itemCount - 1, items.size)
-        Timber.d("item count in inner recyclerview: ${items.size} ${itemCount}")
+    fun addRecommendCourseNextPage(nextPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
+        notifyItemRangeInserted(itemCount - 1, nextPageItems.size)
+        Timber.d("item count in inner recyclerview: ${nextPageItems.size} ${itemCount}")
     }
 
-    fun updateRecommendCourseBySorting(items: List<DiscoverMultiViewItem.RecommendCourse>) {
+    fun updateRecommendCourseBySorting(firstPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
         notifyDataSetChanged()
-        Timber.d("item count in inner recyclerview: ${items.size} ${itemCount}")
+        Timber.d("item count in inner recyclerview: ${firstPageItems.size} ${itemCount}")
     }
 
     companion object {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
@@ -41,7 +41,7 @@ class DiscoverRecommendAdapter(
         private val binding: ItemDiscoverRecommendBinding,
         private val onHeartButtonClick: (Int, Boolean) -> Unit,
         private val onCourseItemClick: (Int) -> Unit,
-        private val handleVisitorMode: () -> Unit,
+        private val handleVisitorMode: () -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(course: DiscoverMultiViewItem.RecommendCourse) {
             with(binding) {
@@ -93,6 +93,10 @@ class DiscoverRecommendAdapter(
         val newList = currentList.toMutableList()
         newList.addAll(items)
         submitList(newList)
+    }
+
+    fun updateRecommendCourseBySorting(items: List<DiscoverMultiViewItem.RecommendCourse>) {
+        submitList(items)
     }
 
     companion object {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
@@ -90,12 +90,13 @@ class DiscoverRecommendAdapter(
     }
 
     fun addRecommendCourseNextPage(items: List<DiscoverMultiViewItem.RecommendCourse>) {
-        val newList = currentList + items
-        submitList(newList)
+        notifyItemRangeInserted(itemCount - 1, items.size)
+        Timber.d("item count in inner recyclerview: ${items.size} ${itemCount}")
     }
 
     fun updateRecommendCourseBySorting(items: List<DiscoverMultiViewItem.RecommendCourse>) {
-        submitList(items)
+        notifyDataSetChanged()
+        Timber.d("item count in inner recyclerview: ${items.size} ${itemCount}")
     }
 
     companion object {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
@@ -11,7 +11,6 @@ import com.runnect.runnect.domain.entity.DiscoverMultiViewItem
 import com.runnect.runnect.presentation.MainActivity
 import com.runnect.runnect.presentation.discover.model.EditableDiscoverCourse
 import com.runnect.runnect.util.callback.diff.ItemDiffCallback
-import okhttp3.internal.wait
 import timber.log.Timber
 
 class DiscoverRecommendAdapter(
@@ -80,14 +79,17 @@ class DiscoverRecommendAdapter(
     }
 
     fun updateRecommendCourseItem(
-        targetIndex: Int,
+        publicCourseId: Int,
         updatedCourse: EditableDiscoverCourse
     ) {
-        currentList[targetIndex].apply {
-            title = updatedCourse.title
-            scrap = updatedCourse.scrap
+        currentList.forEachIndexed { index, course ->
+            if (course.id == publicCourseId) {
+                course.title = updatedCourse.title
+                course.scrap = updatedCourse.scrap
+                notifyItemChanged(index)
+                return
+            }
         }
-        notifyItemChanged(targetIndex)
     }
 
     fun addRecommendCourseNextPage(nextPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
@@ -101,7 +103,7 @@ class DiscoverRecommendAdapter(
         }
     }
 
-    fun updateRecommendCourseBySorting(firstPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
+    fun sortRecommendCourseFirstPage(firstPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
         Timber.d("before item count : $itemCount")
 
         val newList = currentList.toMutableList()

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
@@ -11,6 +11,7 @@ import com.runnect.runnect.domain.entity.DiscoverMultiViewItem
 import com.runnect.runnect.presentation.MainActivity
 import com.runnect.runnect.presentation.discover.model.EditableDiscoverCourse
 import com.runnect.runnect.util.callback.diff.ItemDiffCallback
+import okhttp3.internal.wait
 import timber.log.Timber
 
 class DiscoverRecommendAdapter(
@@ -90,18 +91,33 @@ class DiscoverRecommendAdapter(
     }
 
     fun addRecommendCourseNextPage(nextPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
-        notifyItemRangeInserted(itemCount - 1, nextPageItems.size)
-        Timber.d("item count in inner recyclerview: ${nextPageItems.size} ${itemCount}")
+        Timber.d("before item count : $itemCount")
+
+        val newList = currentList.toMutableList()
+        newList.addAll(nextPageItems)
+
+        submitList(newList) { // 비동기 작업이 끝나고 나서 호출되는 콜백 함수
+            Timber.d("after item count : $itemCount")
+        }
     }
 
     fun updateRecommendCourseBySorting(firstPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
-        notifyDataSetChanged()
-        Timber.d("item count in inner recyclerview: ${firstPageItems.size} ${itemCount}")
+        Timber.d("before item count : $itemCount")
+
+        val newList = currentList.toMutableList()
+        newList.apply {
+            clear()
+            addAll(firstPageItems)
+        }
+
+        submitList(newList) {
+            Timber.d("after item count : $itemCount")
+        }
     }
 
     companion object {
         private val diffUtil = ItemDiffCallback<DiscoverMultiViewItem.RecommendCourse>(
-            onItemsTheSame = { old, new -> old.id == new.id },
+            onItemsTheSame = { old, new -> old === new },
             onContentsTheSame = { old, new -> old == new }
         )
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
@@ -92,6 +92,8 @@ class DiscoverMultiViewAdapter(
 
     fun addRecommendCourseNextPage(items: List<RecommendCourse>) {
         recommendCourses.addAll(items)
+        Timber.d("item count in outer recyclerview: ${items.size} ${recommendCourses.size}")
+
         multiViewHolderFactory.recommendCourseAdapter.addRecommendCourseNextPage(items)
     }
 
@@ -100,6 +102,8 @@ class DiscoverMultiViewAdapter(
             clear()
             addAll(items)
         }
+        Timber.d("item count in outer recyclerview: ${items.size} ${recommendCourses.size}")
+
         multiViewHolderFactory.recommendCourseAdapter.updateRecommendCourseBySorting(items)
     }
 

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
@@ -90,21 +90,21 @@ class DiscoverMultiViewAdapter(
         return viewTypes.indexOfFirst { viewType == it }
     }
 
-    fun addRecommendCourseNextPage(items: List<RecommendCourse>) {
-        recommendCourses.addAll(items)
-        Timber.d("item count in outer recyclerview: ${items.size} ${recommendCourses.size}")
+    fun addRecommendCourseNextPage(nextPageItems: List<RecommendCourse>) {
+        recommendCourses.addAll(nextPageItems)
+        Timber.d("item count in outer recyclerview: ${nextPageItems.size} ${recommendCourses.size}")
 
-        multiViewHolderFactory.recommendCourseAdapter.addRecommendCourseNextPage(items)
+        multiViewHolderFactory.recommendCourseAdapter.addRecommendCourseNextPage(nextPageItems)
     }
 
-    fun updateRecommendCourseBySorting(items: List<RecommendCourse>) {
+    fun updateRecommendCourseBySorting(firstPageItems: List<RecommendCourse>) {
         recommendCourses.apply {
             clear()
-            addAll(items)
+            addAll(firstPageItems)
         }
-        Timber.d("item count in outer recyclerview: ${items.size} ${recommendCourses.size}")
+        Timber.d("item count in outer recyclerview: ${firstPageItems.size} ${recommendCourses.size}")
 
-        multiViewHolderFactory.recommendCourseAdapter.updateRecommendCourseBySorting(items)
+        multiViewHolderFactory.recommendCourseAdapter.updateRecommendCourseBySorting(firstPageItems)
     }
 
     fun updateCourseItem(

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
@@ -5,7 +5,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.runnect.runnect.domain.entity.DiscoverMultiViewItem.MarathonCourse
 import com.runnect.runnect.domain.entity.DiscoverMultiViewItem.RecommendCourse
 import com.runnect.runnect.presentation.discover.model.EditableDiscoverCourse
-import timber.log.Timber
 
 class DiscoverMultiViewAdapter(
     private val onHeartButtonClick: (Int, Boolean) -> Unit,
@@ -93,43 +92,20 @@ class DiscoverMultiViewAdapter(
     }
 
     fun addRecommendCourseNextPage(nextPageItems: List<RecommendCourse>) {
-        recommendCourses.addAll(nextPageItems)
         multiViewHolderFactory.recommendCourseAdapter.addRecommendCourseNextPage(nextPageItems)
     }
 
-    fun updateRecommendCourseBySorting(firstPageItems: List<RecommendCourse>) {
-        recommendCourses.apply {
-            clear()
-            addAll(firstPageItems)
-        }
-        multiViewHolderFactory.recommendCourseAdapter.updateRecommendCourseBySorting(firstPageItems)
+    fun sortRecommendCourseFirstPage(firstPageItems: List<RecommendCourse>) {
+        multiViewHolderFactory.recommendCourseAdapter.sortRecommendCourseFirstPage(firstPageItems)
     }
 
     fun updateCourseItem(
         publicCourseId: Int,
         updatedCourse: EditableDiscoverCourse
     ) {
-        val multiViewItems = marathonCourses + recommendCourses
-        val targetItem = multiViewItems.find { item ->
-            item.id == publicCourseId
-        } ?: return
-
-        when (targetItem) {
-            is MarathonCourse -> {
-                val targetIndex = marathonCourses.indexOf(targetItem)
-                multiViewHolderFactory.marathonCourseAdapter.updateMarathonCourseItem(
-                    targetIndex = targetIndex,
-                    updatedCourse = updatedCourse
-                )
-            }
-
-            is RecommendCourse -> {
-                val targetIndex = recommendCourses.indexOf(targetItem)
-                multiViewHolderFactory.recommendCourseAdapter.updateRecommendCourseItem(
-                    targetIndex = targetIndex,
-                    updatedCourse = updatedCourse
-                )
-            }
+        multiViewHolderFactory.apply {
+            marathonCourseAdapter.updateMarathonCourseItem(publicCourseId, updatedCourse)
+            recommendCourseAdapter.updateRecommendCourseItem(publicCourseId, updatedCourse)
         }
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
@@ -11,6 +11,7 @@ class DiscoverMultiViewAdapter(
     private val onHeartButtonClick: (Int, Boolean) -> Unit,
     private val onCourseItemClick: (Int) -> Unit,
     private val handleVisitorMode: () -> Unit,
+    private val onSortButtonClick: (String) -> Unit
 ) : RecyclerView.Adapter<DiscoverMultiViewHolder>() {
     private val multiViewHolderFactory by lazy { DiscoverMultiViewHolderFactory() }
     private val marathonCourses = arrayListOf<MarathonCourse>()
@@ -23,7 +24,8 @@ class DiscoverMultiViewAdapter(
             viewType = viewType,
             onHeartButtonClick = onHeartButtonClick,
             onCourseItemClick = onCourseItemClick,
-            handleVisitorMode = handleVisitorMode
+            handleVisitorMode = handleVisitorMode,
+            onSortButtonClick = onSortButtonClick
         )
     }
 

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
@@ -36,7 +36,9 @@ class DiscoverMultiViewAdapter(
             }
 
             is DiscoverMultiViewHolder.RecommendCourseViewHolder -> {
-                holder.bind(recommendCourses)
+                // 내부 리사이클러뷰에서는 완전히 새로운 리스트를 참조하도록 깊은 복사 수행
+                val newList = recommendCourses.map { it.copy() }.toList()
+                holder.bind(newList)
             }
         }
     }
@@ -92,8 +94,6 @@ class DiscoverMultiViewAdapter(
 
     fun addRecommendCourseNextPage(nextPageItems: List<RecommendCourse>) {
         recommendCourses.addAll(nextPageItems)
-        Timber.d("item count in outer recyclerview: ${nextPageItems.size} ${recommendCourses.size}")
-
         multiViewHolderFactory.recommendCourseAdapter.addRecommendCourseNextPage(nextPageItems)
     }
 
@@ -102,8 +102,6 @@ class DiscoverMultiViewAdapter(
             clear()
             addAll(firstPageItems)
         }
-        Timber.d("item count in outer recyclerview: ${firstPageItems.size} ${recommendCourses.size}")
-
         multiViewHolderFactory.recommendCourseAdapter.updateRecommendCourseBySorting(firstPageItems)
     }
 

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
@@ -95,6 +95,14 @@ class DiscoverMultiViewAdapter(
         multiViewHolderFactory.recommendCourseAdapter.addRecommendCourseNextPage(items)
     }
 
+    fun updateRecommendCourseBySorting(items: List<RecommendCourse>) {
+        recommendCourses.apply {
+            clear()
+            addAll(items)
+        }
+        multiViewHolderFactory.recommendCourseAdapter.updateRecommendCourseBySorting(items)
+    }
+
     fun updateCourseItem(
         publicCourseId: Int,
         updatedCourse: EditableDiscoverCourse

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
@@ -1,8 +1,12 @@
 package com.runnect.runnect.presentation.discover.adapter.multiview
 
+import android.content.Context
+import android.graphics.Typeface
+import android.widget.TextView
 import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.runnect.runnect.R
 import com.runnect.runnect.databinding.ItemDiscoverMultiviewMarathonBinding
 import com.runnect.runnect.databinding.ItemDiscoverMultiviewRecommendBinding
 import com.runnect.runnect.domain.entity.DiscoverMultiViewItem.MarathonCourse
@@ -13,6 +17,7 @@ import com.runnect.runnect.presentation.discover.model.EditableDiscoverCourse
 import com.runnect.runnect.util.custom.deco.DiscoverMarathonItemDecoration
 import com.runnect.runnect.util.custom.deco.DiscoverRecommendItemDecoration
 import com.runnect.runnect.util.custom.deco.GridSpacingItemDecoration
+import com.runnect.runnect.util.extension.colorOf
 import timber.log.Timber
 
 sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
@@ -105,11 +110,41 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
                 )
             }
         }
-
         private fun initSortButtonClickListener() {
             binding.tvDiscoverRecommendSortByDate.setOnClickListener {
-
+                val context = it.context ?: return@setOnClickListener
+                activateTextStyle(view = it as TextView, context = context)
+                deactivateOtherTextStyle(
+                    view = binding.tvDiscoverRecommendSortByScrap,
+                    context = context
+                )
+                onSortButtonClick.invoke(SORT_BY_DATE)
             }
+
+            binding.tvDiscoverRecommendSortByScrap.setOnClickListener {
+                val context = it.context ?: return@setOnClickListener
+                activateTextStyle(view = it as TextView, context = context)
+                deactivateOtherTextStyle(
+                    view = binding.tvDiscoverRecommendSortByDate,
+                    context = context
+                )
+                onSortButtonClick.invoke(SORT_BY_SCRAP)
+            }
+        }
+
+        private fun activateTextStyle(view: TextView, context: Context) {
+            view.setTextColor(context.colorOf(R.color.M1))
+            view.typeface = context.fontOf(R.font.pretendard_semibold, Typeface.NORMAL)
+        }
+
+        private fun deactivateOtherTextStyle(view: TextView, context: Context) {
+            view.setTextColor(context.colorOf(R.color.G2))
+            view.typeface = context.fontOf(R.font.pretendard_regular, Typeface.NORMAL)
+        }
+
+        companion object {
+            private const val SORT_BY_DATE = "date"
+            private const val SORT_BY_SCRAP = "scrap"
         }
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
@@ -82,7 +82,6 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
         }
 
         fun bind(courses: List<RecommendCourse>) {
-            Timber.d("추천 코스 리스트 크기: ${courses.size}")
             initRecommendRecyclerView(courses)
             initSortButtonClickListener()
         }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
@@ -18,6 +18,7 @@ import com.runnect.runnect.util.custom.deco.DiscoverMarathonItemDecoration
 import com.runnect.runnect.util.custom.deco.DiscoverRecommendItemDecoration
 import com.runnect.runnect.util.custom.deco.GridSpacingItemDecoration
 import com.runnect.runnect.util.extension.colorOf
+import com.runnect.runnect.util.extension.fontOf
 import timber.log.Timber
 
 sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
@@ -111,23 +112,34 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
             }
         }
         private fun initSortButtonClickListener() {
+            initSortByDateClickListener()
+            initSortByScrapClickListener()
+        }
+
+        private fun initSortByDateClickListener() {
             binding.tvDiscoverRecommendSortByDate.setOnClickListener {
                 val context = it.context ?: return@setOnClickListener
+
                 activateTextStyle(view = it as TextView, context = context)
                 deactivateOtherTextStyle(
                     view = binding.tvDiscoverRecommendSortByScrap,
                     context = context
                 )
+
                 onSortButtonClick.invoke(SORT_BY_DATE)
             }
+        }
 
+        private fun initSortByScrapClickListener() {
             binding.tvDiscoverRecommendSortByScrap.setOnClickListener {
                 val context = it.context ?: return@setOnClickListener
+
                 activateTextStyle(view = it as TextView, context = context)
                 deactivateOtherTextStyle(
                     view = binding.tvDiscoverRecommendSortByDate,
                     context = context
                 )
+
                 onSortButtonClick.invoke(SORT_BY_SCRAP)
             }
         }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
@@ -17,6 +17,7 @@ import com.runnect.runnect.util.custom.deco.DiscoverMarathonItemDecoration
 import com.runnect.runnect.util.custom.deco.DiscoverRecommendItemDecoration
 import com.runnect.runnect.util.extension.colorOf
 import com.runnect.runnect.util.extension.fontOf
+import timber.log.Timber
 
 sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
     RecyclerView.ViewHolder(binding.root) {
@@ -88,7 +89,10 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
             binding.rvDiscoverRecommend.apply {
                 layoutManager = GridLayoutManager(context, 2)
                 adapter = recommendAdapter.apply {
-                    submitList(courses)
+                    Timber.e("refresh before item count: ${itemCount}")
+                    submitList(courses) {
+                        Timber.e("refresh after item count: ${itemCount}")
+                    }
                 }
                 addItemDecorationOnlyOnce(this)
             }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
@@ -13,13 +13,10 @@ import com.runnect.runnect.domain.entity.DiscoverMultiViewItem.MarathonCourse
 import com.runnect.runnect.domain.entity.DiscoverMultiViewItem.RecommendCourse
 import com.runnect.runnect.presentation.discover.adapter.DiscoverMarathonAdapter
 import com.runnect.runnect.presentation.discover.adapter.DiscoverRecommendAdapter
-import com.runnect.runnect.presentation.discover.model.EditableDiscoverCourse
 import com.runnect.runnect.util.custom.deco.DiscoverMarathonItemDecoration
 import com.runnect.runnect.util.custom.deco.DiscoverRecommendItemDecoration
-import com.runnect.runnect.util.custom.deco.GridSpacingItemDecoration
 import com.runnect.runnect.util.extension.colorOf
 import com.runnect.runnect.util.extension.fontOf
-import timber.log.Timber
 
 sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
     RecyclerView.ViewHolder(binding.root) {
@@ -83,6 +80,7 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
 
         fun bind(courses: List<RecommendCourse>) {
             initRecommendRecyclerView(courses)
+            initSortButtonTextStyle()
             initSortButtonClickListener()
         }
 
@@ -110,6 +108,17 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
                 )
             }
         }
+
+        private fun initSortButtonTextStyle() {
+            binding.tvDiscoverRecommendSortByDate.apply {
+                activateTextStyle(view = this, context = this.context)
+            }
+
+            binding.tvDiscoverRecommendSortByScrap.apply {
+                deactivateTextStyle(view = this, context = this.context)
+            }
+        }
+
         private fun initSortButtonClickListener() {
             initSortByDateClickListener()
             initSortByScrapClickListener()
@@ -118,13 +127,11 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
         private fun initSortByDateClickListener() {
             binding.tvDiscoverRecommendSortByDate.setOnClickListener {
                 val context = it.context ?: return@setOnClickListener
-
                 activateTextStyle(view = it as TextView, context = context)
-                deactivateOtherTextStyle(
+                deactivateTextStyle(
                     view = binding.tvDiscoverRecommendSortByScrap,
                     context = context
                 )
-
                 onSortButtonClick.invoke(SORT_BY_DATE)
             }
         }
@@ -132,13 +139,11 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
         private fun initSortByScrapClickListener() {
             binding.tvDiscoverRecommendSortByScrap.setOnClickListener {
                 val context = it.context ?: return@setOnClickListener
-
                 activateTextStyle(view = it as TextView, context = context)
-                deactivateOtherTextStyle(
+                deactivateTextStyle(
                     view = binding.tvDiscoverRecommendSortByDate,
                     context = context
                 )
-
                 onSortButtonClick.invoke(SORT_BY_SCRAP)
             }
         }
@@ -148,7 +153,7 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
             view.typeface = context.fontOf(R.font.pretendard_semibold, Typeface.NORMAL)
         }
 
-        private fun deactivateOtherTextStyle(view: TextView, context: Context) {
+        private fun deactivateTextStyle(view: TextView, context: Context) {
             view.setTextColor(context.colorOf(R.color.G2))
             view.typeface = context.fontOf(R.font.pretendard_regular, Typeface.NORMAL)
         }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolder.kt
@@ -65,6 +65,7 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
         onHeartButtonClick: (Int, Boolean) -> Unit,
         onCourseItemClick: (Int) -> Unit,
         handleVisitorMode: () -> Unit,
+        private val onSortButtonClick: (String) -> Unit
     ) : DiscoverMultiViewHolder(binding) {
         val recommendAdapter by lazy {
             DiscoverRecommendAdapter(
@@ -77,6 +78,7 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
         fun bind(courses: List<RecommendCourse>) {
             Timber.d("추천 코스 리스트 크기: ${courses.size}")
             initRecommendRecyclerView(courses)
+            initSortButtonClickListener()
         }
 
         private fun initRecommendRecyclerView(courses: List<RecommendCourse>) {
@@ -101,6 +103,12 @@ sealed class DiscoverMultiViewHolder(binding: ViewDataBinding) :
                         bottomSpacing = 20
                     )
                 )
+            }
+        }
+
+        private fun initSortButtonClickListener() {
+            binding.tvDiscoverRecommendSortByDate.setOnClickListener {
+
             }
         }
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolderFactory.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewHolderFactory.kt
@@ -16,6 +16,7 @@ class DiscoverMultiViewHolderFactory {
         onHeartButtonClick: (Int, Boolean) -> Unit,
         onCourseItemClick: (Int) -> Unit,
         handleVisitorMode: () -> Unit,
+        onSortButtonClick: (String) -> Unit
     ): DiscoverMultiViewHolder {
         when (viewType) {
             DiscoverMultiViewType.MARATHON.ordinal -> {
@@ -34,7 +35,8 @@ class DiscoverMultiViewHolderFactory {
                     binding = parent.getViewDataBinding(layoutRes = R.layout.item_discover_multiview_recommend),
                     onHeartButtonClick = onHeartButtonClick,
                     onCourseItemClick = onCourseItemClick,
-                    handleVisitorMode = handleVisitorMode
+                    handleVisitorMode = handleVisitorMode,
+                    onSortButtonClick = onSortButtonClick
                 )
                 recommendCourseAdapter = viewHolder.recommendAdapter
                 return viewHolder

--- a/app/src/main/java/com/runnect/runnect/util/extension/ContextExt.kt
+++ b/app/src/main/java/com/runnect/runnect/util/extension/ContextExt.kt
@@ -4,6 +4,7 @@ import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
+import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
 import android.net.Uri
 import android.view.Gravity
@@ -13,10 +14,13 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
+import androidx.annotation.FontRes
+import androidx.annotation.StyleRes
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.snackbar.Snackbar
@@ -182,3 +186,6 @@ fun Context.showSnackbar(anchorView: View, message: String, @GravityFlag gravity
 fun Context.colorOf(@ColorRes resId: Int) = ContextCompat.getColor(this, resId)
 
 fun Context.drawableOf(@DrawableRes resId: Int) = ContextCompat.getDrawable(this, resId)
+
+fun Context.fontOf(@FontRes resId: Int, @StyleRes style: Int): Typeface =
+    Typeface.create(ResourcesCompat.getFont(this, resId), style)


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->

closed #307 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->

이슈에 자세한 내용 기록해두었습니다! 

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->

외부 리사이클러뷰 어댑터에서 내부 리사이클러뷰 뷰홀더의 bind 함수에 추천코스 리스트를 넘겨주는 부분이 있는데, 이때 깊은 고민 없이 리스트를 '얕은 복사' 하면서 예기치 못한 문제가 발생했습니다. 현재는 다음과 같이 코드를 수정했어요. 

### AS-IS

```kotlin
override fun onBindViewHolder(holder: DiscoverMultiViewHolder, position: Int) {
    when (holder) {
        is DiscoverMultiViewHolder.MarathonCourseViewHolder -> {
            holder.bind(marathonCourses)
        }

        is DiscoverMultiViewHolder.RecommendCourseViewHolder -> {
            // 이렇게 리스트를 '얕은 복사'해서 넘기면 
            // 내부 리사이클러뷰에서 submitList 하기 전에 
            // 이미 외부 리사이클러뷰의 리스트와 데이터가 동일해짐. 
            holder.bind(recommendCourses)
        }
    }
}
```

### TO-BE

```kotlin
override fun onBindViewHolder(holder: DiscoverMultiViewHolder, position: Int) {
    when (holder) {
        is DiscoverMultiViewHolder.MarathonCourseViewHolder -> {
            holder.bind(marathonCourses)
        }

        is DiscoverMultiViewHolder.RecommendCourseViewHolder -> {
            // 내부 리사이클러뷰에서는 완전히 새로운 리스트를 참조하도록 '깊은 복사' 수행 
	    // 컬렉션의 내부 객체가 가변 객체이므로, map으로 copy까지 해주었음. 
            val newList = recommendCourses.map { it.copy() }.toList()
            holder.bind(newList)
        }
    }
}
```

참고자료: https://seosh817.tistory.com/163

추가적으로 submitList는 비동기적으로 작동하므로, 백그라운드 스레드에서 비동기 작업이 끝난 뒤의 리스트 크기를 출력하고 싶으면 runnable 콜백 함수에서 로그를 찍어야 합니다. 그렇지 않고 그냥 바로 다음 라인에 로그를 찍으면 before, after 리스트 크기가 동일하게 출력됩니다. 저는 이걸 몰라서 계속 로그를 잘못 찍고 있었어요.. 😅

```kotlin
fun addRecommendCourseNextPage(nextPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
	Timber.d("before item count : $itemCount")

	val newList = currentList.toMutableList()
	newList.addAll(nextPageItems)

	submitList(newList) { // 비동기 작업이 끝나고 나서 호출되는 콜백 함수
	    Timber.d("after item count : $itemCount")
	}
}

fun updateRecommendCourseBySorting(firstPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
	Timber.d("before item count : $itemCount")

	val newList = currentList.toMutableList()
	newList.apply {
	    clear()
	    addAll(firstPageItems)
	}

	submitList(newList) {
	    Timber.d("after item count : $itemCount")
	}
}
```

## 📸 스크린샷/동영상
<!--스크린샷을 첨부해주세요 불필요한 경우 생략 가능합니다-->

외부 리사이클러뷰의 리스트를 '얕은 복사'한 경우, 내부 리사이클러뷰에서 이미 페이지가 추가된 리스트에 대하여 중복으로 submitList를 호출하기 때문에 외부와 내부 리사이클러뷰의 추천 코스 리스트가 불일치하는 문제가 발생합니다. (아래는 그로 인해 나타나는 현상)

https://github.com/Runnect/Runnect-Android/assets/68090939/df5adeee-b097-42ba-ab6c-efb4d945df1d
