### PR TITLE
[FIX] 코스 발견 / 스크랩 함수의 로직 수정 

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverMarathonAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverMarathonAdapter.kt
@@ -92,11 +92,16 @@ class DiscoverMarathonAdapter(
     }
 
     fun updateMarathonCourseScrap(
-        targetIndex: Int,
+        publicCourseId: Int,
         scrap: Boolean
     ) {
-        currentList[targetIndex].scrap = scrap
-        notifyItemChanged(targetIndex)
+        currentList.forEachIndexed { index, course ->
+            if (course.id == publicCourseId) {
+                course.scrap = scrap
+                notifyItemChanged(index)
+                return
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/DiscoverRecommendAdapter.kt
@@ -92,11 +92,16 @@ class DiscoverRecommendAdapter(
     }
 
     fun updateRecommendCourseScrap(
-        targetIndex: Int,
+        publicCourseId: Int,
         scrap: Boolean
     ) {
-        currentList[targetIndex].scrap = scrap
-        notifyItemChanged(targetIndex)
+        currentList.forEachIndexed { index, course ->
+            if (course.id == publicCourseId) {
+                course.scrap = scrap
+                notifyItemChanged(index)
+                return
+            }
+        }
     }
 
     fun addRecommendCourseNextPage(nextPageItems: List<DiscoverMultiViewItem.RecommendCourse>) {
@@ -105,7 +110,7 @@ class DiscoverRecommendAdapter(
         val newList = currentList.toMutableList()
         newList.addAll(nextPageItems)
 
-        submitList(newList) { // 비동기 작업이 끝나고 나서 호출되는 콜백 함수
+        submitList(newList) {
             Timber.d("after item count : $itemCount")
         }
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/adapter/multiview/DiscoverMultiViewAdapter.kt
@@ -113,27 +113,9 @@ class DiscoverMultiViewAdapter(
         publicCourseId: Int,
         scrap: Boolean
     ) {
-        val multiViewItems = marathonCourses + recommendCourses
-        val targetItem = multiViewItems.find { item ->
-            item.id == publicCourseId
-        } ?: return
-
-        when (targetItem) {
-            is MarathonCourse -> {
-                val targetIndex = marathonCourses.indexOf(targetItem)
-                multiViewHolderFactory.marathonCourseAdapter.updateMarathonCourseScrap(
-                    targetIndex = targetIndex,
-                    scrap = scrap
-                )
-            }
-
-            is RecommendCourse -> {
-                val targetIndex = recommendCourses.indexOf(targetItem)
-                multiViewHolderFactory.recommendCourseAdapter.updateRecommendCourseScrap(
-                    targetIndex = targetIndex,
-                    scrap = scrap
-                )
-            }
+        multiViewHolderFactory.apply {
+            marathonCourseAdapter.updateMarathonCourseScrap(publicCourseId, scrap)
+            recommendCourseAdapter.updateRecommendCourseScrap(publicCourseId, scrap)
         }
     }
 }


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->

- closed #324 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->

저번 회의 때 외부 리사이클러뷰 어댑터에서는 마라톤, 추천코스 데이터 목록을 쥐고 있지 말자는 얘기가 나왔습니다. 이 데이터 목록들은 내부에 있는 각각의 리사이클러뷰 어댑터에서 처리를 해주는 것이 맞기 때문입니다. 그래서 외부 리사이클러뷰를 처음 초기화 할 때만 사용하는 방식으로 변경했습니다. 

그런데 이때 외부 리사이클러뷰 어댑터의 스크랩 함수에서도 이 데이터 목록들을 사용하고 있다는 것을 깜박하여,,, 해당 부분까지 구현하여 다시 pr 올립니다. 저번에 더 꼼꼼히 확인했어야 했는데 이제야 발견해서 죄송합니다 🥹

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->

이쪽 어댑터에서도 for문으로 아이템 탐색하는 것보다, 클릭한 아이템의 position 값을 어댑터에 저장해두는 게 나을까요?? 그러면 로딩 상태일 때는 [이때](https://github.com/Runnect/Runnect-Android/pull/320#discussion_r1489472416) 논의한 것과 마찬가지로 로딩 프로그레스바를 띄우는 등의 처리가 필요할 거 같습니다. 

