### PR TITLE
[FIX] 코스 상세페이지 / 이전 화면으로 돌아갔을 때 변경사항 바로 반영되도록 

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/dto/UserUploadCourseDTO.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/UserUploadCourseDTO.kt
@@ -3,6 +3,6 @@ package com.runnect.runnect.data.dto
 data class UserUploadCourseDTO(
     val id:Int,
     val img:String,
-    val title:String,
+    var title:String,
     val departure:String
 )

--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
@@ -32,6 +32,7 @@ import com.runnect.runnect.presentation.discover.DiscoverFragment.Companion.EXTR
 import com.runnect.runnect.presentation.discover.model.EditableDiscoverCourse
 import com.runnect.runnect.presentation.discover.search.DiscoverSearchActivity
 import com.runnect.runnect.presentation.login.LoginActivity
+import com.runnect.runnect.presentation.mypage.upload.MyUploadActivity
 import com.runnect.runnect.presentation.profile.ProfileActivity
 import com.runnect.runnect.presentation.state.UiStateV2
 import com.runnect.runnect.util.analytics.Analytics

--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
@@ -179,7 +179,7 @@ class CourseDetailActivity :
             COURSE_STORAGE_SCRAP -> MainActivity.updateStorageScrapScreen()
             COURSE_DISCOVER -> setActivityResult<MainActivity>()
             COURSE_DISCOVER_SEARCH -> setActivityResult<DiscoverSearchActivity>()
-            MY_PAGE_UPLOAD_COURSE -> finish()
+            MY_PAGE_UPLOAD_COURSE -> setActivityResult<MyUploadActivity>()
         }
 
         finish()
@@ -189,7 +189,8 @@ class CourseDetailActivity :
     private inline fun <reified E : Activity> setActivityResult() {
         val updatedCourse = EditableDiscoverCourse(
             title = viewModel.title,
-            scrap = binding.ivCourseDetailScrap.isSelected
+            scrap = binding.ivCourseDetailScrap.isSelected,
+            isDeleted = viewModel.courseDeleteState.value is UiStateV2.Success
         )
 
         Intent(this@CourseDetailActivity, E::class.java).apply {

--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
@@ -179,7 +179,7 @@ class CourseDetailActivity :
             COURSE_STORAGE_SCRAP -> MainActivity.updateStorageScrapScreen()
             COURSE_DISCOVER -> setActivityResult<MainActivity>()
             COURSE_DISCOVER_SEARCH -> setActivityResult<DiscoverSearchActivity>()
-            MY_PAGE_UPLOAD_COURSE -> navigateToMyUploadCourseScreen()
+            MY_PAGE_UPLOAD_COURSE -> finish()
         }
 
         finish()

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/DiscoverFragment.kt
@@ -67,10 +67,14 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
                     result.data?.getCompatibleParcelableExtra(EXTRA_EDITABLE_DISCOVER_COURSE)
                         ?: return@registerForActivityResult
 
-                multiViewAdapter.updateCourseItem(
-                    publicCourseId = viewModel.clickedCourseId,
-                    updatedCourse = updatedCourse
-                )
+                if (updatedCourse.isDeleted) {
+                    refreshDiscoverCourses()
+                } else {
+                    multiViewAdapter.updateCourseItem(
+                        publicCourseId = viewModel.clickedCourseId,
+                        updatedCourse = updatedCourse
+                    )
+                }
             }
         }
 
@@ -155,7 +159,6 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
             ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 super.onPageSelected(position)
-                Timber.d("viewpager position: $position")
                 updateBannerPosition(position)
                 updateBannerIndicatorPosition()
             }
@@ -240,14 +243,18 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
 
     private fun initRefreshLayoutListener() {
         binding.refreshLayout.setOnRefreshListener {
-            // 리프레시 직후에 비어있는 리스트로 리사이클러뷰 초기화
-            multiViewAdapter.initMarathonCourses(emptyList())
-            multiViewAdapter.initRecommendCourses(emptyList())
-
-            // 서버통신 직후에 첫 페이지 데이터로 리사이클러뷰 초기화
-            viewModel.refreshDiscoverCourses()
+            refreshDiscoverCourses()
             binding.refreshLayout.isRefreshing = false
         }
+    }
+
+    fun refreshDiscoverCourses() {
+        // 리프레시 직후에 비어있는 리스트로 리사이클러뷰 초기화
+        multiViewAdapter.initMarathonCourses(emptyList())
+        multiViewAdapter.initRecommendCourses(emptyList())
+
+        // 첫 페이지 데이터로 리사이클러뷰 초기화
+        viewModel.refreshDiscoverCourses()
     }
 
     private fun initSearchButtonClickListener() {
@@ -500,10 +507,6 @@ class DiscoverFragment : BindingFragment<FragmentDiscoverBinding>(R.layout.fragm
     private fun checkRefreshPossibleCondition(): Boolean {
         val layoutManager = binding.rvDiscoverMultiView.layoutManager as LinearLayoutManager
         return layoutManager.findFirstCompletelyVisibleItemPosition() > 0
-    }
-
-    fun refreshDiscoverCourses() {
-        viewModel.refreshDiscoverCourses()
     }
 
     override fun onAttach(context: Context) {

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/model/EditableDiscoverCourse.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/model/EditableDiscoverCourse.kt
@@ -6,5 +6,6 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class EditableDiscoverCourse(
     val title: String,
-    val scrap: Boolean
+    val scrap: Boolean,
+    val isDeleted: Boolean
 ): Parcelable

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/search/DiscoverSearchActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/search/DiscoverSearchActivity.kt
@@ -44,13 +44,28 @@ class DiscoverSearchActivity :
     private val resultLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
+                // 상세페이지 갔다가 이전으로 돌아오면 아이템 변경사항이 바로 반영되도록 (제목, 스크랩)
                 val updatedCourse: EditableDiscoverCourse =
                     result.data?.getCompatibleParcelableExtra(EXTRA_EDITABLE_DISCOVER_COURSE)
                         ?: return@registerForActivityResult
 
-                searchAdapter.updateSearchItem(viewModel.clickedCourseId, updatedCourse)
+                if (updatedCourse.isDeleted) {
+                    searchCourseForKeyword()
+                } else {
+                    searchAdapter.updateSearchItem(
+                        publicCourseId = viewModel.clickedCourseId,
+                        updatedCourse = updatedCourse
+                    )
+                }
             }
         }
+
+    private fun searchCourseForKeyword() {
+        val keyword = binding.etDiscoverSearchTitle.text.toString()
+        if (keyword.isNotBlank()) {
+            viewModel.getCourseSearch(keyword = keyword)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -131,10 +146,10 @@ class DiscoverSearchActivity :
             TextView.OnEditorActionListener {
             override fun onEditorAction(v: TextView?, actionId: Int, event: KeyEvent?): Boolean {
                 if (actionId == IME_ACTION_SEARCH) {
-                    val keyword = binding.etDiscoverSearchTitle.text
-                    if (!keyword.isNullOrBlank()) {
+                    val keyword = binding.etDiscoverSearchTitle.text.toString()
+                    if (keyword.isNotBlank()) {
                         Analytics.logClickedItemEvent(EVENT_CLICK_TRY_SEARCH_COURSE)
-                        viewModel.getCourseSearch(keyword = keyword.toString())
+                        viewModel.getCourseSearch(keyword = keyword)
                         hideKeyboard(binding.etDiscoverSearchTitle)
                     }
                     return true

--- a/app/src/main/java/com/runnect/runnect/presentation/discover/upload/DiscoverUploadActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/discover/upload/DiscoverUploadActivity.kt
@@ -18,6 +18,7 @@ import com.runnect.runnect.presentation.state.UiState
 import com.runnect.runnect.util.analytics.Analytics
 import com.runnect.runnect.util.analytics.EventName.EVENT_CLICK_COURSE_UPLOAD
 import com.runnect.runnect.util.analytics.EventName.VIEW_COURSE_UPLOAD
+import com.runnect.runnect.util.extension.applyScreenExitAnimation
 import com.runnect.runnect.util.extension.getCompatibleParcelableExtra
 import com.runnect.runnect.util.extension.hideKeyboard
 import com.runnect.runnect.util.extension.showToast
@@ -106,12 +107,14 @@ class DiscoverUploadActivity :
     private fun handleReturnToDiscover() {
         showToast("업로드 완료!")
         binding.indeterminateBar.isVisible = false
-        val intent = Intent(this, MainActivity::class.java)
-        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        startActivity(intent)
+
+        Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            startActivity(this)
+        }
+
         MainActivity.updateCourseDiscoverScreen()
-        finish()
-        overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
+        applyScreenExitAnimation()
     }
 
 

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadActivity.kt
@@ -269,10 +269,13 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
     }
 
     private fun handleSuccessfulUploadDeletion() {
-        binding.indeterminateBar.isVisible = false
         uploadAdapter.removeItems(viewModel.itemsToDelete)
         uploadAdapter.clearSelection()
         viewModel.clearItemsToDelete()
+
+        binding.indeterminateBar.isVisible = false
+        binding.constMyPageUploadEditBar.isVisible = true
+        binding.svMyPageUpload.isVisible = true
     }
 
     private fun handleUnsuccessfulUploadCall() {

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadActivity.kt
@@ -1,11 +1,13 @@
 package com.runnect.runnect.presentation.mypage.upload
 
+import android.app.Activity
 import android.app.AlertDialog
 import android.content.ContentValues
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.GridLayoutManager
@@ -14,6 +16,8 @@ import com.runnect.runnect.binding.BindingActivity
 import com.runnect.runnect.databinding.ActivityMyUploadBinding
 import com.runnect.runnect.presentation.detail.CourseDetailActivity
 import com.runnect.runnect.presentation.detail.CourseDetailRootScreen
+import com.runnect.runnect.presentation.discover.DiscoverFragment
+import com.runnect.runnect.presentation.discover.model.EditableDiscoverCourse
 import com.runnect.runnect.presentation.discover.pick.DiscoverPickActivity
 import com.runnect.runnect.presentation.mypage.upload.adapter.MyUploadAdapter
 import com.runnect.runnect.presentation.state.UiState
@@ -21,6 +25,7 @@ import com.runnect.runnect.util.analytics.Analytics
 import com.runnect.runnect.util.analytics.EventName.EVENT_CLICK_COURSE_UPLOAD_IN_UPLOADED_COURSE
 import com.runnect.runnect.util.callback.listener.OnMyUploadItemClick
 import com.runnect.runnect.util.custom.deco.GridSpacingItemDecoration
+import com.runnect.runnect.util.extension.getCompatibleParcelableExtra
 import com.runnect.runnect.util.extension.navigateToPreviousScreenWithAnimation
 import com.runnect.runnect.util.extension.setCustomDialog
 import com.runnect.runnect.util.extension.setDialogButtonClickListener
@@ -33,8 +38,26 @@ import timber.log.Timber
 class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activity_my_upload),
     OnMyUploadItemClick {
     private val viewModel: MyUploadViewModel by viewModels()
-    private lateinit var adapter: MyUploadAdapter
+    private lateinit var uploadAdapter: MyUploadAdapter
     private lateinit var dialog: AlertDialog
+
+    private val resultLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                val updatedCourse: EditableDiscoverCourse =
+                    result.data?.getCompatibleParcelableExtra(DiscoverFragment.EXTRA_EDITABLE_DISCOVER_COURSE)
+                        ?: return@registerForActivityResult
+
+                if (updatedCourse.isDeleted) {
+                    viewModel.getUserUploadCourse()
+                } else {
+                    uploadAdapter.updateMyUploadItem(
+                        publicCourseId = viewModel.clickedCourseId,
+                        updatedCourse = updatedCourse
+                    )
+                }
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,7 +75,6 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
     private fun initLayout() {
         initRecyclerView()
     }
-
 
     private fun initRecyclerView() {
         binding.rvMyPageUpload.layoutManager = GridLayoutManager(this, 2)
@@ -136,20 +158,19 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
     }
 
     private fun initAdapter() {
-        adapter = MyUploadAdapter(this).apply {
+        uploadAdapter = MyUploadAdapter(this).apply {
             submitList(
                 viewModel.myUploadCourses
             )
         }
-        binding.rvMyPageUpload.adapter = adapter
+        binding.rvMyPageUpload.adapter = uploadAdapter
     }
 
     private fun addObserver() {
-
         viewModel.myUploadCourseState.observe(this) {
             when (it) {
                 UiState.Empty -> handleEmptyUploadCourse()
-                UiState.Loading -> binding.indeterminateBar.isVisible = true
+                UiState.Loading -> handleLoadingUploadCourse()
                 UiState.Success -> handleSuccessfulCourseLoad()
                 UiState.Failure -> handleUnsuccessfulUploadCall()
             }
@@ -158,11 +179,10 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
         viewModel.myUploadDeleteState.observe(this) {
             updateDeleteButton(viewModel.selectedItemsCount.value ?: 0)
             when (it) {
-                UiState.Loading -> binding.indeterminateBar.isVisible = true
+                UiState.Empty -> handleEmptyUploadCourse()
+                UiState.Loading -> handleLoadingUploadCourse()
                 UiState.Success -> handleSuccessfulUploadDeletion()
                 UiState.Failure -> handleUnsuccessfulUploadCall()
-                else -> binding.indeterminateBar.isVisible = false
-
             }
         }
 
@@ -185,7 +205,7 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
         with(binding) {
             btnMyPageUploadEditCourse.text = EDIT_CANCEL
             tvMyPageUploadTotalCourseCount.text = DESCRIPTION_CHOICE_MODE
-            if (::adapter.isInitialized) adapter.handleCheckBoxVisibility(true)
+            if (::uploadAdapter.isInitialized) uploadAdapter.handleCheckBoxVisibility(true)
         }
     }
 
@@ -195,9 +215,9 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
             btnMyPageUploadEditCourse.text = EDIT_MODE
             tvMyPageUploadTotalCourseCount.text = viewModel.getCourseCount()
             tvMyPageUploadDelete.isVisible = viewModel.editMode.value!!
-            if (::adapter.isInitialized) {
-                adapter.clearSelection()
-                adapter.handleCheckBoxVisibility(false)
+            if (::uploadAdapter.isInitialized) {
+                uploadAdapter.clearSelection()
+                uploadAdapter.handleCheckBoxVisibility(false)
             }
             viewModel.clearItemsToDelete()
         }
@@ -218,20 +238,40 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
         }
     }
 
+    private fun handleEmptyUploadCourse() {
+        with(binding) {
+            indeterminateBar.isVisible = false
+            constMyPageUploadEditBar.isVisible = false
+            svMyPageUpload.isVisible = false
+            layoutMyPageUploadNoResult.isVisible = true
+        }
+    }
+
+    private fun handleLoadingUploadCourse() {
+        with(binding) {
+            indeterminateBar.isVisible = true
+            constMyPageUploadEditBar.isVisible = false
+            svMyPageUpload.isVisible = false
+        }
+    }
+
     private fun handleSuccessfulCourseLoad() {
         with(binding) {
             indeterminateBar.isVisible = false
+            layoutMyPageUploadNoResult.isVisible = false
+
             tvMyPageUploadTotalCourseCount.text = viewModel.getCourseCount()
             constMyPageUploadEditBar.isVisible = true
-            layoutMyPageUploadNoResult.isVisible = false
+            svMyPageUpload.isVisible = true
         }
+
         initAdapter()
     }
 
     private fun handleSuccessfulUploadDeletion() {
         binding.indeterminateBar.isVisible = false
-        adapter.removeItems(viewModel.itemsToDelete)
-        adapter.clearSelection()
+        uploadAdapter.removeItems(viewModel.itemsToDelete)
+        uploadAdapter.clearSelection()
         viewModel.clearItemsToDelete()
     }
 
@@ -240,25 +280,18 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
         Timber.tag(ContentValues.TAG).d("Failure : ${viewModel.errorMessage.value}")
     }
 
-    private fun handleEmptyUploadCourse() {
-        with(binding) {
-            indeterminateBar.isVisible = false
-            constMyPageUploadEditBar.isVisible = false
-            layoutMyPageUploadNoResult.isVisible = true
-        }
-    }
-
     override fun selectItem(id: Int): Boolean {
         return if (viewModel.editMode.value == true) {
             Timber.tag(ContentValues.TAG).d("코스 아이디 : $id")
             viewModel.modifyItemsToDelete(id)
             true
         } else {
-            val intent = Intent(this, CourseDetailActivity::class.java).apply {
+            viewModel.saveClickedCourseId(id)
+            Intent(this, CourseDetailActivity::class.java).apply {
                 putExtra(EXTRA_PUBLIC_COURSE_ID, id)
                 putExtra(EXTRA_ROOT_SCREEN, CourseDetailRootScreen.MY_PAGE_UPLOAD_COURSE)
+                resultLauncher.launch(this)
             }
-            startActivity(intent)
             false
         }
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadViewModel.kt
@@ -42,6 +42,13 @@ class MyUploadViewModel @Inject constructor(private val userRepository: UserRepo
 
     val selectCountMediator = MediatorLiveData<List<Int>>()
 
+    private var _clickedCourseId = -1
+    val clickedCourseId get() = _clickedCourseId
+
+    fun saveClickedCourseId(id: Int) {
+        _clickedCourseId = id
+    }
+
     init {
         selectCountMediator.addSource(itemsToDeleteLiveData) {
             setSelectedItemsCount(_itemsToDelete.count())

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/adapter/MyUploadAdapter.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/adapter/MyUploadAdapter.kt
@@ -10,6 +10,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.DecodeFormat
 import com.runnect.runnect.data.dto.UserUploadCourseDTO
 import com.runnect.runnect.databinding.ItemMypageUploadBinding
+import com.runnect.runnect.presentation.discover.model.EditableDiscoverCourse
 import com.runnect.runnect.util.callback.diff.ItemDiffCallback
 import com.runnect.runnect.util.callback.listener.OnMyUploadItemClick
 
@@ -87,6 +88,16 @@ class MyUploadAdapter(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    fun updateMyUploadItem(publicCourseId: Int, updatedCourse: EditableDiscoverCourse) {
+        currentList.forEachIndexed { index, course ->
+            if (course.id == publicCourseId) {
+                course.title = updatedCourse.title
+                notifyItemChanged(index)
+                return@forEachIndexed
             }
         }
     }


### PR DESCRIPTION
## 📌 개요
<!--이슈 번호 및 제목을 적어주세요-->

- closed #330 

## ✨ 작업 내용
<!--어떤 작업을 했는지 작성해주세요-->

코스 상세페이지에서 본인이 업로드한 코스인 경우, 수정/삭제가 가능합니다. 상세페이지에서 이런 변경사항이 발생했을 때, 이전 화면에 바로 반영되도록 구현했습니다. 

- 코스 발견: DiscoverFragment, DiscoverMultiViewAdapter
- 코스 검색: DiscoverSearchActivity, DiscoverSearchAdapter
- 마이페이지 내가 업로드한 코스: MyUploadActivity, MyUploadAdapter  

```kotlin
private fun navigateToPreviousScreen() {
    if (isFromDeepLink) {
        navigateToMainScreenWithBundle()
        isFromDeepLink = false
        return
    }

    when (rootScreen) {
        COURSE_STORAGE_SCRAP -> MainActivity.updateStorageScrapScreen()
        COURSE_DISCOVER -> setActivityResult<MainActivity>()
        COURSE_DISCOVER_SEARCH -> setActivityResult<DiscoverSearchActivity>()
        MY_PAGE_UPLOAD_COURSE -> setActivityResult<MyUploadActivity>()
    }

    finish()
    overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
}

private inline fun <reified E : Activity> setActivityResult() {
    val updatedCourse = EditableDiscoverCourse(
        title = viewModel.title,
        scrap = binding.ivCourseDetailScrap.isSelected,
        isDeleted = viewModel.courseDeleteState.value is UiStateV2.Success
    )

    Intent(this@CourseDetailActivity, E::class.java).apply {
        putExtra(EXTRA_EDITABLE_DISCOVER_COURSE, updatedCourse)
        setResult(RESULT_OK, this)
    }
}
```

## ✨ PR 포인트
<!--특별히 더 봐주면 좋겠는 부분 / 고민됐던 내용 등을 적어주세요! 필요하다면 해당 코드 부분을 직접 짚어주세요!-->

특정 항목의 변경사항을 이전 화면에 바로 반영시키는, 또 다른 방법이나 아이디어가 있으시다면 언제든 피드백 부탁드립니다! 
