### PR TITLE
[REFACTOR] kotlin-android-extensions 제거 후 viewBinding, kotlinx-parcelize 도입

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,8 +2,7 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
 
-    id 'kotlin-android-extensions'
-    //id 'kotlin-parcelize'
+    id 'kotlin-parcelize'
 
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.7.20'
     id 'dagger.hilt.android.plugin'

--- a/app/src/main/java/com/runnect/runnect/data/dto/CourseData.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/CourseData.kt
@@ -3,7 +3,7 @@ package com.runnect.runnect.data.dto
 
 import android.os.Parcelable
 import com.naver.maps.geometry.LatLng
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CourseData(

--- a/app/src/main/java/com/runnect/runnect/data/dto/RunToEndRunData.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/RunToEndRunData.kt
@@ -2,7 +2,7 @@ package com.runnect.runnect.data.dto
 
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class RunToEndRunData(

--- a/app/src/main/java/com/runnect/runnect/data/dto/SearchResultEntity.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/SearchResultEntity.kt
@@ -2,7 +2,7 @@ package com.runnect.runnect.data.dto
 
 import android.os.Parcelable
 import com.naver.maps.geometry.LatLng
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class SearchResultEntity(

--- a/app/src/main/java/com/runnect/runnect/data/dto/TimerData.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/TimerData.kt
@@ -2,7 +2,7 @@ package com.runnect.runnect.data.dto
 
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class TimerData(

--- a/app/src/main/java/com/runnect/runnect/domain/entity/DiscoverUploadCourse.kt
+++ b/app/src/main/java/com/runnect/runnect/domain/entity/DiscoverUploadCourse.kt
@@ -1,7 +1,7 @@
 package com.runnect.runnect.domain.entity
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class DiscoverUploadCourse(

--- a/app/src/main/java/com/runnect/runnect/domain/entity/MyDrawCourse.kt
+++ b/app/src/main/java/com/runnect/runnect/domain/entity/MyDrawCourse.kt
@@ -1,7 +1,7 @@
 package com.runnect.runnect.domain.entity
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class MyDrawCourse(

--- a/app/src/main/java/com/runnect/runnect/domain/entity/MyScrapCourse.kt
+++ b/app/src/main/java/com/runnect/runnect/domain/entity/MyScrapCourse.kt
@@ -2,7 +2,7 @@ package com.runnect.runnect.domain.entity
 
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class MyScrapCourse(

--- a/app/src/main/java/com/runnect/runnect/presentation/draw/DrawActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/draw/DrawActivity.kt
@@ -41,6 +41,7 @@ import com.runnect.runnect.data.dto.SearchResultEntity
 import com.runnect.runnect.data.dto.UploadLatLng
 import com.runnect.runnect.databinding.ActivityDrawBinding
 import com.runnect.runnect.databinding.BottomsheetRequireCourseNameBinding
+import com.runnect.runnect.databinding.CustomDialogMakeCourseBinding
 import com.runnect.runnect.presentation.MainActivity
 import com.runnect.runnect.presentation.countdown.CountDownActivity
 import com.runnect.runnect.presentation.state.UiState
@@ -54,8 +55,6 @@ import com.runnect.runnect.util.extension.setActivityDialog
 import com.runnect.runnect.util.extension.showToast
 import com.runnect.runnect.util.multipart.ContentUriRequestBody
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.custom_dialog_make_course.view.btn_run
-import kotlinx.android.synthetic.main.custom_dialog_make_course.view.btn_storage
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -502,15 +501,14 @@ class DrawActivity : BindingActivity<ActivityDrawBinding>(R.layout.activity_draw
      * 코스 완성 시 뜨는 팝업 (보관함 가기 / 바로 달리기)
      */
     private fun notifyCreateFinish() { //todo dialogFragment로 리팩토링
+        val binding = CustomDialogMakeCourseBinding.inflate(layoutInflater)
         val (dialog, dialogLayout) = setActivityDialog(
             layoutInflater = layoutInflater,
-            view = binding.root,
-            resId = R.layout.custom_dialog_make_course,
+            binding = binding,
             cancel = false
         )
-
-        with(dialogLayout) {
-            this.btn_run.setOnClickListener {
+        with(binding) {
+            btnRun.setOnClickListener {
                 Analytics.logClickedItemEvent(EventName.EVENT_CLICK_RUN_AFTER_COURSE_COMPLETE)
                 if (isCustomLocationMode) departureLatLng = customDepartureLatLng
 
@@ -539,7 +537,7 @@ class DrawActivity : BindingActivity<ActivityDrawBinding>(R.layout.activity_draw
                 dialog.dismiss()
             }
 
-            this.btn_storage.setOnClickListener {
+            btnStorage.setOnClickListener {
                 Analytics.logClickedItemEvent(EventName.EVENT_CLICK_STORED_AFTER_COURSE_COMPLETE)
                 val intent = Intent(this@DrawActivity, MainActivity::class.java).apply {
                     putExtra(EXTRA_FRAGMENT_REPLACEMENT_DIRECTION, "fromDrawCourse")

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/history/MyHistoryActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/history/MyHistoryActivity.kt
@@ -33,6 +33,7 @@ import timber.log.Timber
 class MyHistoryActivity : BindingActivity<ActivityMyHistoryBinding>(R.layout.activity_my_history),
     OnMyHistoryItemClick {
     private val viewModel: MyHistoryViewModel by viewModels()
+    private lateinit var deleteDialogDeleteBinding: CustomDialogDeleteBinding
     private lateinit var adapter: MyHistoryAdapter
     private lateinit var dialog: AlertDialog
 
@@ -66,18 +67,18 @@ class MyHistoryActivity : BindingActivity<ActivityMyHistoryBinding>(R.layout.act
     }
 
     private fun initDialog() {
-        val binding = CustomDialogDeleteBinding.inflate(layoutInflater)
+        deleteDialogDeleteBinding = CustomDialogDeleteBinding.inflate(layoutInflater)
         dialog = setCustomDialog(
-            binding = binding,
+            binding = deleteDialogDeleteBinding,
             description = DIALOG_DESC,
             yesBtnText = DELETE_BTN
         )
     }
 
-    private fun setDialogClickEvent(binding: CustomDialogDeleteBinding) {
-        dialog.setDialogButtonClickListener(binding) { which ->
+    private fun setDialogClickEvent() {
+        dialog.setDialogButtonClickListener(deleteDialogDeleteBinding) { which ->
             when (which) {
-                binding.btnDeleteYes -> viewModel.deleteHistory()
+                deleteDialogDeleteBinding.btnDeleteYes -> viewModel.deleteHistory()
             }
         }
     }
@@ -112,8 +113,7 @@ class MyHistoryActivity : BindingActivity<ActivityMyHistoryBinding>(R.layout.act
 
     private fun handleDeleteButtonClicked(it: View) {
         if (it.isEnabled) {
-            val binding = CustomDialogDeleteBinding.inflate(LayoutInflater.from(it.context))
-            setDialogClickEvent(binding)
+            setDialogClickEvent()
             dialog.show()
         }
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/history/MyHistoryActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/history/MyHistoryActivity.kt
@@ -4,6 +4,7 @@ import android.app.AlertDialog
 import android.content.ContentValues
 import android.content.Intent
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
@@ -13,6 +14,7 @@ import com.runnect.runnect.R
 import com.runnect.runnect.binding.BindingActivity
 import com.runnect.runnect.data.dto.HistoryInfoDTO
 import com.runnect.runnect.databinding.ActivityMyHistoryBinding
+import com.runnect.runnect.databinding.CustomDialogDeleteBinding
 import com.runnect.runnect.presentation.mypage.history.adapter.MyHistoryAdapter
 import com.runnect.runnect.presentation.mypage.history.detail.MyHistoryDetailActivity
 import com.runnect.runnect.presentation.search.SearchActivity
@@ -25,7 +27,6 @@ import com.runnect.runnect.util.extension.navigateToPreviousScreenWithAnimation
 import com.runnect.runnect.util.extension.setCustomDialog
 import com.runnect.runnect.util.extension.setDialogButtonClickListener
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.custom_dialog_delete.btn_delete_yes
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -65,18 +66,18 @@ class MyHistoryActivity : BindingActivity<ActivityMyHistoryBinding>(R.layout.act
     }
 
     private fun initDialog() {
+        val binding = CustomDialogDeleteBinding.inflate(layoutInflater)
         dialog = setCustomDialog(
-            layoutInflater = layoutInflater,
-            view = binding.root,
+            binding = binding,
             description = DIALOG_DESC,
             yesBtnText = DELETE_BTN
         )
     }
 
-    private fun setDialogClickEvent() {
-        dialog.setDialogButtonClickListener { which ->
+    private fun setDialogClickEvent(binding: CustomDialogDeleteBinding) {
+        dialog.setDialogButtonClickListener(binding) { which ->
             when (which) {
-                dialog.btn_delete_yes -> viewModel.deleteHistory()
+                binding.btnDeleteYes -> viewModel.deleteHistory()
             }
         }
     }
@@ -111,7 +112,8 @@ class MyHistoryActivity : BindingActivity<ActivityMyHistoryBinding>(R.layout.act
 
     private fun handleDeleteButtonClicked(it: View) {
         if (it.isEnabled) {
-            setDialogClickEvent()
+            val binding = CustomDialogDeleteBinding.inflate(LayoutInflater.from(it.context))
+            setDialogClickEvent(binding)
             dialog.show()
         }
     }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/accountinfo/MySettingAccountInfoFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/accountinfo/MySettingAccountInfoFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.replace
 import androidx.fragment.app.viewModels
 import com.runnect.runnect.R
 import com.runnect.runnect.binding.BindingFragment
+import com.runnect.runnect.databinding.CustomDialogDeleteBinding
 import com.runnect.runnect.databinding.FragmentMySettingAccountInfoBinding
 import com.runnect.runnect.presentation.login.LoginActivity
 import com.runnect.runnect.presentation.mypage.setting.MySettingFragment
@@ -28,7 +29,6 @@ import com.runnect.runnect.util.extension.showToast
 import com.runnect.runnect.util.preference.AuthUtil.saveToken
 import com.runnect.runnect.util.preference.StatusType.LoginStatus
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.custom_dialog_delete.btn_delete_yes
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -49,9 +49,7 @@ class MySettingAccountInfoFragment :
         addListener()
         addObserver()
         initLogoutDialog()
-        setLogoutDialogClickEvent()
         initWithdrawalDialog()
-        setWithdrawalDialogClickEvent()
     }
 
     private fun initLayout() {
@@ -105,10 +103,14 @@ class MySettingAccountInfoFragment :
     }
 
     private fun initLogoutDialog() {
+        val binding = CustomDialogDeleteBinding.inflate(layoutInflater)
         logoutDialog = requireActivity().setCustomDialog(
-            layoutInflater, binding.root, DESCRIPTION_LOGOUT,
-            DESCRIPTION_LOGOUT_YES, DESCRIPTION_LOGOUT_NO
+            binding = binding,
+            description = DESCRIPTION_LOGOUT,
+            yesBtnText = DESCRIPTION_LOGOUT_YES,
+            noBtnText = DESCRIPTION_LOGOUT_NO
         )
+        setLogoutDialogClickEvent(binding)
     }
 
     private fun moveToLogin() {
@@ -123,10 +125,10 @@ class MySettingAccountInfoFragment :
         requireActivity().finish()
     }
 
-    private fun setLogoutDialogClickEvent() {
-        logoutDialog.setDialogButtonClickListener { which ->
+    private fun setLogoutDialogClickEvent(binding: CustomDialogDeleteBinding) {
+        logoutDialog.setDialogButtonClickListener(binding) { which ->
             when (which) {
-                logoutDialog.btn_delete_yes -> {
+                binding.btnDeleteYes -> {
                     Analytics.logClickedItemEvent(EVENT_VIEW_SUCCESS_LOGOUT)
                     moveToLogin()
                 }
@@ -135,16 +137,20 @@ class MySettingAccountInfoFragment :
     }
 
     private fun initWithdrawalDialog() {
+        val binding = CustomDialogDeleteBinding.inflate(layoutInflater)
         withdrawalDialog = requireActivity().setCustomDialog(
-            layoutInflater, binding.root, DESCRIPTION_WITHDRAWAL,
-            DESCRIPTION_WITHDRAWAL_YES, DESCRIPTION_WITHDRAWAL_NO
+            binding = binding,
+            description = DESCRIPTION_WITHDRAWAL,
+            yesBtnText = DESCRIPTION_WITHDRAWAL_YES,
+            noBtnText = DESCRIPTION_WITHDRAWAL_NO
         )
+        setWithdrawalDialogClickEvent(binding)
     }
 
-    private fun setWithdrawalDialogClickEvent() {
-        withdrawalDialog.setDialogButtonClickListener { which ->
+    private fun setWithdrawalDialogClickEvent(binding: CustomDialogDeleteBinding) {
+        withdrawalDialog.setDialogButtonClickListener(binding) { which ->
             when (which) {
-                withdrawalDialog.btn_delete_yes -> {
+                binding.btnDeleteYes -> {
                     viewModel.deleteUser()
                 }
             }

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/upload/MyUploadActivity.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.runnect.runnect.R
 import com.runnect.runnect.binding.BindingActivity
 import com.runnect.runnect.databinding.ActivityMyUploadBinding
+import com.runnect.runnect.databinding.CustomDialogDeleteBinding
 import com.runnect.runnect.presentation.detail.CourseDetailActivity
 import com.runnect.runnect.presentation.detail.CourseDetailRootScreen
 import com.runnect.runnect.presentation.discover.DiscoverFragment
@@ -31,8 +32,6 @@ import com.runnect.runnect.util.extension.setCustomDialog
 import com.runnect.runnect.util.extension.setDialogButtonClickListener
 import com.runnect.runnect.util.extension.showSnackbar
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.custom_dialog_delete.btn_delete_no
-import kotlinx.android.synthetic.main.custom_dialog_delete.btn_delete_yes
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -41,6 +40,7 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
     private val viewModel: MyUploadViewModel by viewModels()
     private lateinit var uploadAdapter: MyUploadAdapter
     private lateinit var dialog: AlertDialog
+    private lateinit var dialogBinding: CustomDialogDeleteBinding
 
     private val resultLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -135,23 +135,25 @@ class MyUploadActivity : BindingActivity<ActivityMyUploadBinding>(R.layout.activ
         }
     }
 
+
     private fun initDialog() {
+        dialogBinding = CustomDialogDeleteBinding.inflate(layoutInflater)
         dialog = setCustomDialog(
-            layoutInflater, binding.root,
-            DESCRIPTION_DIALOG,
-            DELETE_BTN
+            binding = dialogBinding,
+            description = DESCRIPTION_DIALOG,
+            yesBtnText = DELETE_BTN
         )
     }
 
     private fun setDialogClickEvent() {
-        dialog.setDialogButtonClickListener { which ->
+        dialog.setDialogButtonClickListener(dialogBinding) { which ->
             when (which) {
-                dialog.btn_delete_yes -> {
+                dialogBinding.btnDeleteYes -> {
                     viewModel.deleteUploadCourse()
                     dialog.dismiss()
                 }
 
-                dialog.btn_delete_no -> {
+                dialogBinding.btnDeleteNo -> {
                     dialog.dismiss()
                 }
             }

--- a/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/storage/StorageMyDrawFragment.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import android.widget.Button
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.ContextCompat
@@ -31,8 +32,6 @@ import com.runnect.runnect.util.custom.deco.GridSpacingItemDecoration
 import com.runnect.runnect.util.extension.applyScreenEnterAnimation
 import com.runnect.runnect.util.extension.setFragmentDialog
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.custom_dialog_delete.view.*
-import kotlinx.android.synthetic.main.fragment_storage_my_draw.*
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -199,25 +198,26 @@ class StorageMyDrawFragment :
 
     private fun showCourseDeleteConfirmDialog() {
         val (dialog, dialogLayout) = setFragmentDialog(
-            layoutInflater = layoutInflater,
             resId = R.layout.custom_dialog_delete,
             cancel = true
         )
-        with(dialogLayout) {
-            this.btn_delete_yes.setOnClickListener {
-                deleteCourse()
-                dialog.dismiss()
-                availableEdit = false
-                isSelectAvailable = false
-                hideDeleteCourseBtn()
-                showBottomNav()
-            }
-            this.btn_delete_no.setOnClickListener {
-                dialog.dismiss()
-            }
+
+        dialogLayout.findViewById<Button>(R.id.btn_delete_yes)?.setOnClickListener {
+            deleteCourse()
+            dialog.dismiss()
+            availableEdit = false
+            isSelectAvailable = false
+            hideDeleteCourseBtn()
+            showBottomNav()
         }
+
+        dialogLayout.findViewById<Button>(R.id.btn_delete_no)?.setOnClickListener {
+            dialog.dismiss()
+        }
+
         dialog.show()
     }
+
 
     private fun deleteCourse() {
         viewModel.deleteMyDrawCourse()

--- a/app/src/main/java/com/runnect/runnect/util/extension/ContextExt.kt
+++ b/app/src/main/java/com/runnect/runnect/util/extension/ContextExt.kt
@@ -25,41 +25,32 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
+import androidx.viewbinding.ViewBinding
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.transition.SlideDistanceProvider.GravityFlag
 import com.runnect.runnect.R
-import kotlinx.android.synthetic.main.custom_dialog_delete.btn_delete_no
-import kotlinx.android.synthetic.main.custom_dialog_delete.view.btn_delete_no
-import kotlinx.android.synthetic.main.custom_dialog_delete.view.btn_delete_yes
-import kotlinx.android.synthetic.main.custom_dialog_delete.view.tv_dialog
-import kotlinx.android.synthetic.main.custom_dialog_edit_mode.layout_delete_frame
-import kotlinx.android.synthetic.main.custom_dialog_edit_mode.layout_edit_frame
-import kotlinx.android.synthetic.main.fragment_bottom_sheet.btn_delete_yes
+import com.runnect.runnect.databinding.CustomDialogDeleteBinding
+import com.runnect.runnect.databinding.CustomDialogEditModeBinding
 import timber.log.Timber
-import java.lang.IllegalArgumentException
-import java.lang.NullPointerException
 
 fun Context.setActivityDialog(
     layoutInflater: LayoutInflater,
-    view: View,
-    resId: Int,
+    binding: ViewBinding,
     cancel: Boolean
 ): Pair<AlertDialog, View> {
-    val dialogLayout = layoutInflater.inflate(resId, null)
-    val build = AlertDialog.Builder(view.context).apply {
-        setView(dialogLayout)
+    val build = AlertDialog.Builder(this).apply {
+        setView(binding.root)
     }
     val dialog = build.create()
     dialog.setCancelable(cancel) // 외부 영역 터치 금지
     dialog.window!!.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-    return Pair(dialog, dialogLayout)
+    return Pair(dialog, binding.root)
 }
 
 fun Fragment.setFragmentDialog(
-    layoutInflater: LayoutInflater,
     resId: Int,
-    cancel: Boolean,
+    cancel: Boolean
 ): Pair<AlertDialog, View> {
     val dialogLayout = layoutInflater.inflate(resId, null)
     val build = AlertDialog.Builder(requireContext()).apply {
@@ -71,21 +62,19 @@ fun Fragment.setFragmentDialog(
     return Pair(dialog, dialogLayout)
 }
 
+
 fun Context.setCustomDialog(
-    layoutInflater: LayoutInflater,
-    view: View,
+    binding: CustomDialogDeleteBinding,
     description: String,
     yesBtnText: String,
     noBtnText: String = "취소"
 ): AlertDialog {
-    val dialogLayout = layoutInflater.inflate(R.layout.custom_dialog_delete, null)
-    with(dialogLayout) {
-        tv_dialog.text = description
-        btn_delete_no.text = noBtnText
-        btn_delete_yes.text = yesBtnText
-    }
-    val build = AlertDialog.Builder(view.context).apply {
-        setView(dialogLayout)
+    binding.tvDialog.text = description
+    binding.btnDeleteNo.text = noBtnText
+    binding.btnDeleteYes.text = yesBtnText
+
+    val build = AlertDialog.Builder(this).apply {
+        setView(binding.root)
     }
     val dialog = build.create()
     dialog.setCancelable(false) //외부 영역 터치 금지
@@ -93,52 +82,53 @@ fun Context.setCustomDialog(
     return dialog
 }
 
-fun AlertDialog.setDialogButtonClickListener(listener: (which: AppCompatButton) -> Unit) {
+fun AlertDialog.setDialogButtonClickListener(
+    binding: CustomDialogDeleteBinding,
+    listener: (which: AppCompatButton) -> Unit
+) {
     this.setOnShowListener {
-        val yesButton = this.btn_delete_yes
-        val noButton = this.btn_delete_no
-        yesButton.setOnClickListener {
-            listener(yesButton)
+        binding.btnDeleteYes.setOnClickListener {
+            listener(binding.btnDeleteYes)
             this.dismiss()
         }
-        noButton.setOnClickListener {
-            listener(noButton)
+        binding.btnDeleteNo.setOnClickListener {
+            listener(binding.btnDeleteNo)
             this.dismiss()
         }
     }
 }
 
-fun Context.setEditBottomSheet(): BottomSheetDialog {
-    val bottomSheetDialog = BottomSheetDialog(
-        this, R.style.BottomSheetDialogTheme
-    )
-    val bottomSheetView = LayoutInflater.from(this).inflate(
-        R.layout.custom_dialog_edit_mode, null
-    )
-    bottomSheetDialog.setContentView(bottomSheetView)
+fun Context.setEditBottomSheet(binding: CustomDialogEditModeBinding): BottomSheetDialog {
+    val bottomSheetDialog = BottomSheetDialog(this, R.style.BottomSheetDialogTheme)
+    bottomSheetDialog.setContentView(binding.root)
     return bottomSheetDialog
 }
 
-fun BottomSheetDialog.setEditBottomSheetClickListener(listener: (which: LinearLayoutCompat) -> Unit) {
+
+fun BottomSheetDialog.setEditBottomSheetClickListener(
+    binding: CustomDialogEditModeBinding,
+    listener: (which: LinearLayoutCompat) -> Unit
+) {
     this.setOnShowListener {
-        val editButton = this.layout_edit_frame
-        val deleteButton = this.layout_delete_frame
-        editButton.setOnClickListener {
-            listener(editButton)
+        binding.layoutEditFrame.setOnClickListener {
+            listener(binding.layoutEditFrame)
             dismiss()
         }
-        deleteButton.setOnClickListener {
-            listener(deleteButton)
+        binding.layoutDeleteFrame.setOnClickListener {
+            listener(binding.layoutDeleteFrame)
             dismiss()
         }
     }
 }
 
-fun BottomSheetDialog.handleEditTextValue(){
+
+fun BottomSheetDialog.handleEditTextValue(binding: CustomDialogEditModeBinding) {
     this.setOnShowListener {
-        val editText = this.layout_edit_frame
+        val editText = binding.layoutEditFrame
+        // Handle the editText as needed
     }
 }
+
 
 fun Context.getStampResId(
     stampId: String?,
@@ -148,7 +138,7 @@ fun Context.getStampResId(
 ): Int {
     with(this) {
         var resName = ""
-        if(stampId == "CSPR0"){
+        if (stampId == "CSPR0") {
             resName = "${resNameParam}basic"
             return resources.getIdentifier(
                 resName,
@@ -179,7 +169,11 @@ fun Context.showToast(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
 }
 
-fun Context.showSnackbar(anchorView: View, message: String, @GravityFlag gravity: Int = Gravity.BOTTOM) {
+fun Context.showSnackbar(
+    anchorView: View,
+    message: String,
+    @GravityFlag gravity: Int = Gravity.BOTTOM
+) {
     val snackbar = Snackbar.make(anchorView, message, Snackbar.LENGTH_SHORT)
     val layoutParams = snackbar.view.layoutParams as? CoordinatorLayout.LayoutParams
     layoutParams?.apply {


### PR DESCRIPTION
## 📌 개요
- closed #285 

## ✨ 작업 내용
- kotlin-android-extensions 를 제거하고 parcelize 플러그인 추가
- viewBinding으로 기존의 익스텐션 대체

## ✨ PR 포인트
이제 컴포즈 버전업하면 될 것 같습니다 ~! 기존 다이얼로그 동작 잘되나 다 확인하긴 했는데 그래도 한번씩 실행부탁드려요 

그리고 기존 contextExt 로직을 유지하는 선에서 딱 제거작업만 해서 findViewById와 같은 개선할만한 사항이 남아있긴 합니다 컴포즈로 이전할 예정이라서 개선없이 그냥 두었어요 : )


