### PR TITLE
RunActivity 타이머 크래시 수정 및 서버 URL prod 고정

### DIFF
--- a/app/src/main/java/com/runnect/runnect/application/ApplicationClass.kt
+++ b/app/src/main/java/com/runnect/runnect/application/ApplicationClass.kt
@@ -39,20 +39,22 @@ class ApplicationClass : Application() {
         lateinit var appContext: Context
         const val API_MODE = "API_MODE"
 
-        fun getBaseUrl(): String {
-            return when {
-                !BuildConfig.DEBUG -> BuildConfig.RUNNECT_PROD_URL
-                !::appContext.isInitialized -> BuildConfig.RUNNECT_PROD_URL
-                else -> {
-                    val mode = ApiMode.getCurrentApiMode(appContext)
-                    Timber.d("현재 서버: ${mode}")
-                    when (mode) {
-                        ApiMode.JAVA -> BuildConfig.RUNNECT_PROD_URL
-                        ApiMode.TEST -> BuildConfig.RUNNECT_DEV_URL
-                        else -> BuildConfig.RUNNECT_NODE_URL
-                    }
-                }
-            }
-        }
+        // TODO: dev/node 서버 복구 시 분기 복원
+//        fun getBaseUrl(): String {
+//            return when {
+//                !BuildConfig.DEBUG -> BuildConfig.RUNNECT_PROD_URL
+//                !::appContext.isInitialized -> BuildConfig.RUNNECT_PROD_URL
+//                else -> {
+//                    val mode = ApiMode.getCurrentApiMode(appContext)
+//                    Timber.d("현재 서버: ${mode}")
+//                    when (mode) {
+//                        ApiMode.JAVA -> BuildConfig.RUNNECT_PROD_URL
+//                        ApiMode.TEST -> BuildConfig.RUNNECT_DEV_URL
+//                        else -> BuildConfig.RUNNECT_NODE_URL
+//                    }
+//                }
+//            }
+//        }
+        fun getBaseUrl(): String = BuildConfig.RUNNECT_PROD_URL
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/run/RunActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/run/RunActivity.kt
@@ -124,7 +124,7 @@ class RunActivity : BindingActivity<ActivityRunBinding>(R.layout.activity_run),
     override fun onStart() {
         super.onStart()
         // Timer 결과값을 받기 위해 브로드캐스트 리시버 등록
-        registerReceiver(timerReceiver, IntentFilter(TIMER_UPDATE_ACTION))
+        registerReceiver(timerReceiver, IntentFilter(TIMER_UPDATE_ACTION), RECEIVER_NOT_EXPORTED)
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/runnect/runnect/presentation/run/TimerService.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/run/TimerService.kt
@@ -73,6 +73,7 @@ class TimerService : Service() {
                         second = second
                     )
                 )
+                intent.setPackage(packageName)
                 sendBroadcast(intent)
 
                 // 알림의 내용 업데이트


### PR DESCRIPTION
## 작업 배경
- Android 14+에서 RunActivity 진입 시 `registerReceiver`에 `RECEIVER_EXPORTED/NOT_EXPORTED` 플래그 누락으로 SecurityException 크래시 발생
- 디버그 빌드에서 dev/node 서버(미운영)를 바라보는 문제로 API 요청 타임아웃

## 변경 사항

| 구분 | 파일 | 내용 |
|------|------|------|
| 수정 | `RunActivity.kt` | `registerReceiver`에 `RECEIVER_NOT_EXPORTED` 플래그 추가 |
| 수정 | `TimerService.kt` | `sendBroadcast`에 `setPackage(packageName)` 추가하여 앱 내부 전달 보장 |
| 수정 | `ApplicationClass.kt` | `getBaseUrl()` 분기 주석 처리, prod URL 고정 반환 |

## 영향 범위
- RunActivity: Android 14+ 크래시 해소 + 타이머 UI 정상 수신
- 전체 API: 디버그 빌드에서도 prod 서버 사용으로 통일
- 기존 서버 분기 로직은 주석 처리되어 추후 복원 가능

## Test Plan
- [x] 디버그 빌드 성공 확인
- [ ] RunActivity 진입 → 타이머 정상 표시 확인
- [ ] 디버그 빌드에서 로그인 → API 통신 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API endpoint configuration to consistently use production URLs
  * Improved broadcast receiver registration for enhanced security and stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->