### PR TITLE
Remote Config force_update 플래그 기반 업데이트 팝업 제어

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -84,6 +84,11 @@ jobs:
           KAKAO_CHANNEL_ID: ${{ secrets.KAKAO_CHANNEL_ID }}
         run: echo "KAKAO_CHANNEL_ID=\"$KAKAO_CHANNEL_ID\"" >> local.properties
 
+      - name: Access REMOTE_KEY_FORCE_UPDATE
+        env:
+          REMOTE_KEY_FORCE_UPDATE: ${{ secrets.REMOTE_KEY_FORCE_UPDATE }}
+        run: echo "REMOTE_KEY_FORCE_UPDATE=\"$REMOTE_KEY_FORCE_UPDATE\"" >> local.properties
+
       - name: Access KEY_ALIAS
         env:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,6 +79,11 @@ jobs:
               env:
                   KAKAO_CHANNEL_ID: ${{ secrets.KAKAO_CHANNEL_ID }}
               run: echo "KAKAO_CHANNEL_ID=\"$KAKAO_CHANNEL_ID\"" >> local.properties
+
+            - name: Access REMOTE_KEY_FORCE_UPDATE
+              env:
+                  REMOTE_KEY_FORCE_UPDATE: ${{ secrets.REMOTE_KEY_FORCE_UPDATE }}
+              run: echo "REMOTE_KEY_FORCE_UPDATE=\"$REMOTE_KEY_FORCE_UPDATE\"" >> local.properties
               
             - name: Add kakao_strings.xml
               env:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,7 @@ android {
         buildConfigField "String", "NAVER_CLIENT_ID", properties["NAVER_CLIENT_ID"]
         buildConfigField "String", "GOOGLE_CLIENT_ID", properties["GOOGLE_CLIENT_ID"]
         buildConfigField "String", "REMOTE_KEY_APP_VERSION", properties["REMOTE_KEY_APP_VERSION"]
+        buildConfigField "String", "REMOTE_KEY_FORCE_UPDATE", properties["REMOTE_KEY_FORCE_UPDATE"]
         buildConfigField "String", "KAKAO_CHANNEL_ID", properties["KAKAO_CHANNEL_ID"]
     }
 

--- a/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
@@ -136,8 +136,9 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
             fetchAndActivate().addOnCompleteListener { task ->
                 if (task.isSuccessful) {
+                    val forceUpdate = getBoolean(REMOTE_KEY_FORCE_UPDATE)
                     val updateAppVersion = getString(REMOTE_KEY_APP_VERSION)
-                    if (localAppVersion != updateAppVersion) {
+                    if (forceUpdate && localAppVersion != updateAppVersion) {
                         initUpdateDialog()
                     }
                 }
@@ -163,6 +164,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     companion object {
         const val REMOTE_CONFIG_FETCH_INTERVAL_SECONDS = 3600L
+        const val REMOTE_KEY_FORCE_UPDATE = "force_update"
         const val EXTRA_FRAGMENT_REPLACEMENT_DIRECTION = "fragmentReplacementDirection"
     }
 }

--- a/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/MainActivity.kt
@@ -9,6 +9,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.remoteconfig.remoteConfig
 import com.google.firebase.remoteconfig.remoteConfigSettings
 import com.runnect.runnect.BuildConfig.REMOTE_KEY_APP_VERSION
+import com.runnect.runnect.BuildConfig.REMOTE_KEY_FORCE_UPDATE
 import com.runnect.runnect.R
 import com.runnect.runnect.binding.BindingActivity
 import com.runnect.runnect.databinding.ActivityMainBinding
@@ -164,7 +165,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     companion object {
         const val REMOTE_CONFIG_FETCH_INTERVAL_SECONDS = 3600L
-        const val REMOTE_KEY_FORCE_UPDATE = "force_update"
         const val EXTRA_FRAGMENT_REPLACEMENT_DIRECTION = "fragmentReplacementDirection"
     }
 }


### PR DESCRIPTION
## 작업 배경
- 기존에는 앱 버전이 다르기만 하면 무조건 강제 업데이트 팝업이 떠서 사용성을 저해
- Firebase Remote Config의 `force_update` 파라미터로 팝업 노출 여부를 서버에서 제어할 수 있도록 개선

## 변경 사항

| 구분 | 파일 | 내용 |
|------|------|------|
| 수정 | `MainActivity.kt` | `force_update == true && 버전 다름` 조건일 때만 팝업 표시 |
| 수정 | `MainActivity.kt` | `REMOTE_KEY_FORCE_UPDATE` 상수 추가 |

## 영향 범위
- 앱 진입 시 업데이트 팝업 노출 조건 변경
- `force_update = false` (기본값) → 팝업 미노출
- `force_update = true` + 버전 불일치 → 강제 업데이트 팝업 (외부 터치 차단)
- 앱 배포 없이 Firebase Remote Config 콘솔에서 즉시 제어 가능

## Test Plan
- [x] 디버그 빌드 성공 확인
- [ ] Remote Config `force_update = false` 시 팝업 미노출 확인
- [ ] Remote Config `force_update = true` + 구버전 시 팝업 노출 확인
- [ ] 팝업 외부 영역 터치 시 닫히지 않는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update prompt behavior refined: the app will now only show a mandatory update dialog when a remote "force update" flag is enabled and a newer app version is detected. This reduces unnecessary prompts and makes mandatory update enforcement more deliberate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->