### PR TITLE
fix: 16KB 페이지 사이즈 지원 + CourseDetail lateinit 크래시 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,12 @@ android {
         }
     }
 
+    packaging {
+        jniLibs {
+            useLegacyPackaging = false
+        }
+    }
+
     applicationVariants.all { variant ->
         variant.outputs.all {
             def timestamp = new Date().format('yyyyMMdd_HHmmss')

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Runnect"
         android:usesCleartextTraffic="true"
+        android:extractNativeLibs="false"
         tools:targetApi="tiramisu">
 
         <service

--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
@@ -407,10 +407,12 @@ class CourseDetailActivity :
             COURSE_STORAGE_SCRAP -> lifecycleScope.launch {
                 screenRefreshEventBus.emit(ScreenRefreshEvent.RefreshStorageScrap)
             }
-            COURSE_DISCOVER -> setActivityResult<MainActivity>()
             COURSE_DISCOVER_SEARCH -> setActivityResult<DiscoverSearchActivity>()
             MY_PAGE_UPLOAD_COURSE -> setActivityResult<MyUploadActivity>()
-            null -> {}
+            COURSE_DISCOVER, null -> {
+                navigateToMainScreen()
+                return
+            }
         }
 
         finish()

--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
@@ -79,7 +79,7 @@ class CourseDetailActivity :
     private var isFromDeepLink: Boolean = false
 
     // 인텐트 부가 데이터
-    private lateinit var rootScreen: CourseDetailRootScreen
+    private var rootScreen: CourseDetailRootScreen? = null
     private var publicCourseId: Int = -1
 
     // 서버통신으로 초기화 할 데이터
@@ -410,6 +410,7 @@ class CourseDetailActivity :
             COURSE_DISCOVER -> setActivityResult<MainActivity>()
             COURSE_DISCOVER_SEARCH -> setActivityResult<DiscoverSearchActivity>()
             MY_PAGE_UPLOAD_COURSE -> setActivityResult<MyUploadActivity>()
+            null -> {}
         }
 
         finish()


### PR DESCRIPTION
## 작업 배경
- Play Store 심사에서 16KB 페이지 사이즈 미지원 및 `UninitializedPropertyAccessException` 크래시로 반려

## 변경 사항

### 1. 16KB 페이지 사이즈 지원
- `AndroidManifest.xml`: `android:extractNativeLibs="false"` 추가
- `app/build.gradle`: `packaging { jniLibs { useLegacyPackaging = false } }` 추가
- [공식 문서](https://developer.android.com/guide/practices/page-sizes)

### 2. CourseDetailActivity lateinit 크래시 수정
- `rootScreen: CourseDetailRootScreen`을 `lateinit` → `nullable`로 변경
- 딥링크로 진입 시 `EXTRA_ROOT_SCREEN` extra가 없어서 초기화되지 않은 채 `navigateToPreviousScreen()`에서 접근하면 크래시 발생
- `when` 분기에 `null -> {}` 추가하여 안전하게 처리

## 영향 범위
- 16KB: 네이티브 라이브러리 패키징 방식 변경 (앱 동작에 영향 없음)
- lateinit: 딥링크 진입 → 뒤로가기 시나리오에서만 영향

## Test Plan
- [x] Debug 빌드 성공
- [ ] 릴리즈 AAB 빌드 후 Play Store 재제출
- [ ] 딥링크 진입 → 뒤로가기 시 크래시 없는지 확인
- [ ] 일반 경로(발견/보관함/업로드) 진입 → 뒤로가기 정상 동작 확인