### PR TITLE
feat: R8 난독화 및 리소스 축소 활성화

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -3,24 +3,14 @@
 # ===========================
 # 각 라이브러리의 공식 문서 또는 공식 저장소에 근거한 규칙만 포함합니다.
 # consumer rules로 자동 적용되는 라이브러리는 별도 규칙을 추가하지 않습니다.
-# (Retrofit, OkHttp, Kotlin Serialization, Glide, Naver Map SDK, DataBinding, Hilt)
+# (Retrofit, OkHttp, Kotlin Serialization, Glide, Naver Map SDK, DataBinding, Hilt, Gson)
 
 # --- Firebase Crashlytics ---
 # 난독화된 스택 트레이스를 읽을 수 있도록 소스 파일명/라인 번호 유지
 # 공식 문서: https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports?platform=android
 -keepattributes SourceFile,LineNumberTable
 -keep public class * extends java.lang.Exception
--renamesourcefileattribute SourceFile
 
 # --- Kakao SDK ---
 # 공식 문서: https://developers.kakao.com/docs/latest/en/android/getting-started#configure-for-shrinking-and-obfuscation-(optional)
 -keep class com.kakao.sdk.**.model.* { <fields>; }
-
-# --- Gson ---
-# Gson 2.13.x JAR에 consumer rules가 포함되어 있지 않으므로 수동 추가 필요
-# 공식 규칙 파일: https://github.com/google/gson/blob/main/gson/src/main/resources/META-INF/proguard/gson.pro
-# 공식 트러블슈팅: https://github.com/google/gson/blob/main/Troubleshooting.md#r8-agp
--keep class * extends com.google.gson.TypeAdapter
--keepclassmembers,allowobfuscation class * {
-    @com.google.gson.annotations.SerializedName <fields>;
-}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,25 +1,26 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# ===========================
+# Runnect ProGuard/R8 Rules
+# ===========================
+# 각 라이브러리의 공식 문서 또는 공식 저장소에 근거한 규칙만 포함합니다.
+# consumer rules로 자동 적용되는 라이브러리는 별도 규칙을 추가하지 않습니다.
+# (Retrofit, OkHttp, Kotlin Serialization, Glide, Naver Map SDK, DataBinding, Hilt)
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# --- Firebase Crashlytics ---
+# 난독화된 스택 트레이스를 읽을 수 있도록 소스 파일명/라인 번호 유지
+# 공식 문서: https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports?platform=android
+-keepattributes SourceFile,LineNumberTable
+-keep public class * extends java.lang.Exception
+-renamesourcefileattribute SourceFile
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
-
-# https://developers.kakao.com/docs/latest/en/getting-started/sdk-android#configure-for-shrinking-and-obfuscation-(optional)
+# --- Kakao SDK ---
+# 공식 문서: https://developers.kakao.com/docs/latest/en/android/getting-started#configure-for-shrinking-and-obfuscation-(optional)
 -keep class com.kakao.sdk.**.model.* { <fields>; }
+
+# --- Gson ---
+# Gson 2.13.x JAR에 consumer rules가 포함되어 있지 않으므로 수동 추가 필요
+# 공식 규칙 파일: https://github.com/google/gson/blob/main/gson/src/main/resources/META-INF/proguard/gson.pro
+# 공식 트러블슈팅: https://github.com/google/gson/blob/main/Troubleshooting.md#r8-agp
 -keep class * extends com.google.gson.TypeAdapter
+-keepclassmembers,allowobfuscation class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}


### PR DESCRIPTION
## Summary
- 릴리즈 빌드에 R8 난독화(`minifyEnabled true`) 및 리소스 축소(`shrinkResources true`) 적용
- 서드파티 공식 문서 기반 ProGuard rules 작성 (Firebase Crashlytics, Kakao SDK, Gson)
- consumer rules로 자동 적용되는 라이브러리는 별도 규칙 미추가 (Retrofit, OkHttp, Kotlin Serialization, Glide, Naver Map SDK, DataBinding, Hilt)

## AAB 용량 비교
| | 용량 | 비고 |
|---|---|---|
| 난독화 전 | 54.5MB (57,141,698 bytes) | `minifyEnabled false` |
| 난독화 후 | 46.8MB (49,119,764 bytes) | `minifyEnabled true` + `shrinkResources true` |
| **절감량** | **-7.6MB (14% 감소)** | |

## ProGuard Rules 근거
각 규칙의 공식 근거는 PR 코멘트에 인라인으로 첨부합니다.

## Test Plan
- [ ] 릴리즈 AAB 빌드 성공 확인
- [ ] 카카오 로그인 정상 동작 확인
- [ ] Retrofit API 호출 정상 동작 확인 (Gson/Kotlin Serialization 직렬화)
- [ ] Naver Map 정상 렌더링 확인
- [ ] Firebase Crashlytics 크래시 리포트 난독화 해제 확인
- [ ] Glide/Coil 이미지 로딩 정상 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled code and resource minification for release builds to reduce app size and improve performance.
  * Updated obfuscation/shrinking rules to better preserve crash reporting data and key third‑party library models for more reliable diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->