### PR TITLE
fix: R8 난독화 시 Retrofit API 호출 실패 해결

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,6 +11,18 @@
 -keepattributes SourceFile,LineNumberTable
 -keep public class * extends java.lang.Exception
 
+# --- Retrofit + kotlin.Result ---
+# kotlin.Result는 inline class라 R8이 제네릭 타입 정보를 최적화함
+# Retrofit이 Call<Result<T>>의 타입 파라미터를 리플렉션으로 읽지 못해 CallAdapter 생성 실패
+# https://github.com/square/retrofit/issues/3880
+-keep class kotlin.Result { *; }
+-keepattributes Signature
+
+# --- DTO ---
+# Gson 리플렉션으로 역직렬화되는 DTO 클래스의 필드명 보존
+# (BaseResponse, ErrorResponse 등이 ResponseInterceptor에서 Gson으로 파싱됨)
+-keepclassmembers class com.runnect.runnect.data.dto.response.base.** { <fields>; }
+
 # --- Kakao SDK ---
 # 공식 문서: https://developers.kakao.com/docs/latest/en/android/getting-started#configure-for-shrinking-and-obfuscation-(optional)
 -keep class com.kakao.sdk.**.model.* { <fields>; }


### PR DESCRIPTION
## 작업 배경
R8 난독화(#379) 적용 후 릴리즈 빌드에서 모든 API 호출이 실패하는 버그 발생. 디버그 빌드에서는 정상 동작.

## 원인 분석

### 1. kotlin.Result 제네릭 타입 소실
- `kotlin.Result`는 inline(value) class → R8이 제네릭 Signature 속성을 최적화
- Retrofit이 `Call<Result<T>>`의 타입 파라미터를 리플렉션으로 읽지 못함
- `ResultCallAdapterFactory`에서 `IllegalArgumentException: Unable to create call adapter` 발생
- **이 에러로 인해 모든 API 요청이 아예 나가지 않았음**

### 2. BaseResponse DTO 필드명 난독화
- `ResponseInterceptor`에서 Gson으로 `BaseResponse`를 역직렬화
- `BaseResponse`는 `@SerialName`(Kotlin Serialization)만 선언, `@SerializedName`(Gson) 없음
- R8이 필드명을 난독화하면 Gson 매핑 실패

## 변경 사항 (`app/proguard-rules.pro`)
```
# kotlin.Result inline class 보존
-keep class kotlin.Result { *; }
-keepattributes Signature

# BaseResponse/ErrorResponse 필드명 보존 (Gson 역직렬화용)
-keepclassmembers class com.runnect.runnect.data.dto.response.base.** { <fields>; }
```

## 영향 범위
- 릴리즈 빌드의 모든 API 호출에 영향
- ProGuard rules 추가만으로 코드 변경 없음

## Test Plan
- [x] 릴리즈 APK 빌드 → 실 디바이스 설치 → 방문자 모드 API 정상 응답 확인
- [ ] 카카오/구글 로그인 정상 동작 확인
- [ ] 에러 응답 파싱 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure proper app functionality and reliability when compiled for release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->