### PR TITLE
fix: 마이페이지 설정 화면이 보관함 탭에 겹쳐 나오는 버그 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -160,6 +160,9 @@
             android:name=".presentation.mypage.upload.MyUploadActivity"
             android:exported="false" />
         <activity
+            android:name=".presentation.mypage.setting.MySettingActivity"
+            android:exported="false" />
+        <activity
             android:name=".presentation.profile.ProfileActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageFragment.kt
@@ -14,8 +14,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.commit
-import androidx.fragment.app.replace
 import com.kakao.sdk.common.util.KakaoCustomTabsClient
 import com.kakao.sdk.talk.TalkApiClient
 import com.runnect.runnect.BuildConfig
@@ -25,7 +23,7 @@ import com.runnect.runnect.presentation.login.LoginActivity
 import com.runnect.runnect.presentation.mypage.editname.MyPageEditNameActivity
 import com.runnect.runnect.presentation.mypage.history.MyHistoryActivity
 import com.runnect.runnect.presentation.mypage.reward.MyRewardActivity
-import com.runnect.runnect.presentation.mypage.setting.MySettingFragment
+import com.runnect.runnect.presentation.mypage.setting.MySettingActivity
 import com.runnect.runnect.presentation.mypage.upload.MyUploadActivity
 import com.runnect.runnect.presentation.ui.theme.RunnectTheme
 import com.runnect.runnect.util.analytics.Analytics
@@ -122,11 +120,11 @@ class MyPageFragment : Fragment() {
     }
 
     private fun moveToSettingFragment() {
-        val bundle = Bundle().apply { putString(ACCOUNT_INFO_TAG, viewModel.currentState.email) }
-        requireActivity().supportFragmentManager.commit {
-            setCustomAnimations(R.anim.slide_in_right, R.anim.slide_out_left)
-            replace<MySettingFragment>(R.id.fl_main, args = bundle)
+        val intent = Intent(requireContext(), MySettingActivity::class.java).apply {
+            putExtra(ACCOUNT_INFO_TAG, viewModel.currentState.email)
         }
+        startActivity(intent)
+        requireActivity().overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
     }
 
     private fun inquiryKakao() {

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingActivity.kt
@@ -1,0 +1,29 @@
+package com.runnect.runnect.presentation.mypage.setting
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
+import com.runnect.runnect.R
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MySettingActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_my_setting)
+
+        if (savedInstanceState == null) {
+            val bundle = Bundle().apply {
+                putString(
+                    MySettingFragment.ACCOUNT_INFO_TAG,
+                    intent.getStringExtra(MySettingFragment.ACCOUNT_INFO_TAG)
+                )
+            }
+            supportFragmentManager.commit {
+                replace<MySettingFragment>(R.id.fl_main, args = bundle)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingFragment.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/setting/MySettingFragment.kt
@@ -12,7 +12,6 @@ import com.runnect.runnect.BuildConfig
 import com.runnect.runnect.R
 import com.runnect.runnect.binding.BindingFragment
 import com.runnect.runnect.databinding.FragmentMySettingBinding
-import com.runnect.runnect.presentation.mypage.MyPageFragment
 import com.runnect.runnect.presentation.mypage.setting.accountinfo.MySettingAccountInfoFragment
 import com.runnect.runnect.util.extension.showWebBrowser
 
@@ -57,10 +56,8 @@ class MySettingFragment : BindingFragment<FragmentMySettingBinding>(R.layout.fra
     }
 
     private fun navigateToMyPageFragment() {
-        parentFragmentManager.commit {
-            setCustomAnimations(R.anim.slide_in_left, R.anim.slide_out_right)
-            replace<MyPageFragment>(R.id.fl_main)
-        }
+        requireActivity().finish()
+        requireActivity().overridePendingTransition(R.anim.slide_in_left, R.anim.slide_out_right)
     }
 
     private fun moveToMySettingAccountInfo() {

--- a/app/src/main/res/layout/activity_my_setting.xml
+++ b/app/src/main/res/layout/activity_my_setting.xml
@@ -2,4 +2,5 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/fl_main"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true" />

--- a/app/src/main/res/layout/activity_my_setting.xml
+++ b/app/src/main/res/layout/activity_my_setting.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fl_main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />


### PR DESCRIPTION
## 작업 배경
마이페이지에서 설정 클릭 시 `R.id.fl_main`에 fragment replace 했는데, 이 컨테이너는 보관함 탭(`fragment_storage_main.xml`)에만 존재. 설정 화면이 보관함 영역에 겹쳐서 표시되고, 탭 전환 시에도 남아있는 버그.

## 변경 사항
- `MySettingActivity` 신규 생성 — 설정 화면을 독립 Activity로 분리
- `MyPageFragment.moveToSettingFragment()` — fragment replace → Activity 시작으로 변경
- `MySettingFragment.navigateToMyPageFragment()` — fragment replace → `finish()`로 변경
- `AndroidManifest.xml`에 `MySettingActivity` 등록

## 영향 범위
- 마이페이지 → 설정 → 계정 정보 네비게이션 전체
- `MySettingFragment` 내부의 `fl_main` 사용은 유지 (Activity 내 컨테이너로 정상 동작)

## Test Plan
- [x] `./gradlew assembleRelease` 빌드 성공
- [ ] 마이페이지 → 설정 이동 정상 확인
- [ ] 설정 → 뒤로가기 → 마이페이지 복귀 확인
- [ ] 설정 → 계정 정보 → 뒤로가기 흐름 확인
- [ ] 설정 진입 후 다른 탭 전환 시 겹침 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)