### PR TITLE
fix: 코스 상세 뒤로가기 시 메인 화면 재생성 버그 수정

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/detail/CourseDetailActivity.kt
@@ -409,7 +409,8 @@ class CourseDetailActivity :
             }
             COURSE_DISCOVER_SEARCH -> setActivityResult<DiscoverSearchActivity>()
             MY_PAGE_UPLOAD_COURSE -> setActivityResult<MyUploadActivity>()
-            COURSE_DISCOVER, null -> {
+            COURSE_DISCOVER -> { /* finish()로 이전 MainActivity(코스 발견 탭)로 복귀 */ }
+            null -> {
                 navigateToMainScreen()
                 return
             }


### PR DESCRIPTION
## 작업 배경
코스 발견 → 코스 상세 → 뒤로가기 시, 이전 MainActivity로 돌아가지 않고 새 MainActivity를 `FLAG_ACTIVITY_CLEAR_TASK`로 생성. 탭 0(코스 그리기)이 잠깐 보인 뒤 탭 2(코스 발견)로 전환되는 부자연스러운 동작 발생.

## 변경 사항
- `CourseDetailActivity.navigateToPreviousScreen()`에서 `COURSE_DISCOVER` 케이스를 `navigateToMainScreen()` → `finish()`로 변경
- 이전 MainActivity(코스 발견 탭 선택 상태)가 그대로 복귀
- `rootScreen`이 `null`인 경우(진입 경로 불명)만 `navigateToMainScreen()` 유지

## 영향 범위
- 코스 발견 탭에서 코스 상세 진입 후 뒤로가기 동작

## Test Plan
- [x] `./gradlew assembleRelease` 빌드 성공
- [ ] 코스 발견 → 코스 상세 → 뒤로가기 → 코스 발견 탭 유지 확인
- [ ] 보관함(스크랩) → 코스 상세 → 뒤로가기 정상 확인
- [ ] 딥링크 → 코스 상세 → 뒤로가기 → 메인 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)