### PR TITLE
마이페이지 레벨 프로그레스바 stop indicator 렌더링 오류 수정

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/mypage/MyPageScreen.kt
@@ -209,6 +209,8 @@ private fun LevelProgressSection(
                 .clip(RoundedCornerShape(5.dp)),
             color = M1,
             trackColor = G4,
+            drawStopIndicator = {},
+            gapSize = 0.dp,
         )
         Spacer(modifier = Modifier.height(10.dp))
         Row(


### PR DESCRIPTION
## 작업 배경
- Material3 최신 버전(BOM 2026.03.01)에서 `LinearProgressIndicator`가 기본적으로 트랙 끝에 stop indicator(작은 점)를 그리는 스펙 변경
- `levelPercent = 0`일 때도 오른쪽 끝에 점이 표시되어 바가 꽉 찬 것처럼 보이는 시각적 오류 발생

## 변경 사항

| 파일 | 변경 내용 |
|---|---|
| `MyPageScreen.kt` | `LinearProgressIndicator`에 `drawStopIndicator = {}`, `gapSize = 0.dp` 추가 |

## 영향 범위
- 마이페이지 레벨 프로그레스바 렌더링에만 영향
- 런타임 동작 변경 없음, 시각적 수정만

## Test Plan
- [x] `levelPercent = 0`일 때 빈 바로 표시되는지 확인
- [ ] 다양한 `levelPercent` 값(0, 50, 100)에서 바 채움 비율이 정확한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the level progress indicator appearance on the My Page screen with visual enhancements for a cleaner, more polished presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->