### PR TITLE
fix: TimerService 재시작 시 MediaPlayer IllegalStateException 크래시 수정

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/run/TimerService.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/run/TimerService.kt
@@ -45,7 +45,8 @@ class TimerService : Service() {
         if (player == null) {
             player = MediaPlayer.create(this@TimerService, R.raw.start_run)
             player?.setOnCompletionListener { mediaPlayer ->
-                mediaPlayer.release() // 재생이 끝나면 MediaPlayer 객체를 해제합니다.
+                mediaPlayer.release()
+                player = null
             }
         }
         player?.start()


### PR DESCRIPTION
## 작업 배경
- v2.3.0 디바이스 테스트 중 러닝 시작 시 앱 크래시 발생
- `TimerService.notifyStartRun()`에서 `IllegalStateException` 발생

## 변경 사항
| 파일 | 변경 내용 |
|------|-----------|
| `TimerService.kt` | `setOnCompletionListener`에서 `release()` 후 `player = null` 추가 |

**버그 원인:**
- `setOnCompletionListener`에서 `mediaPlayer.release()`를 호출하지만 `player` 참조를 null로 초기화하지 않음
- 서비스는 `START_STICKY`라 시스템에 의해 재시작될 수 있음
- 재시작 시 `onStartCommand()` → `notifyStartRun()` 호출
- `if (player == null)` 조건이 false (player는 released 상태이지만 non-null)
- released 상태의 `player?.start()` 호출 → `IllegalStateException`

**수정:**
```kotlin
player?.setOnCompletionListener { mediaPlayer ->
    mediaPlayer.release()
    player = null  // 추가
}
```

## 영향 범위
- `TimerService.notifyStartRun()` 메서드만 영향
- 서비스 재시작 시나리오에서 크래시 방지
- 정상 플로우(최초 시작)에서는 동작 변화 없음

## Test Plan
- [x] 코드 로직 검증 (MediaPlayer state machine 참조)
- [ ] 기기에서 러닝 시작 → 앱 백그라운드 → 서비스 재시작 시나리오 테스트
- [ ] 정상 러닝 시작/종료 플로우 회귀 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)