### PR TITLE
fix: 코스 그리기 저장 시 로딩바 미표시 버그 수정

### DIFF
--- a/app/src/main/java/com/runnect/runnect/presentation/draw/DrawViewModel.kt
+++ b/app/src/main/java/com/runnect/runnect/presentation/draw/DrawViewModel.kt
@@ -13,7 +13,6 @@ import com.runnect.runnect.presentation.state.UiState
 import com.runnect.runnect.util.extension.collectResult
 import com.runnect.runnect.util.multipart.ContentUriRequestBody
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.onStart
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.math.acos
@@ -85,6 +84,7 @@ class DrawViewModel @Inject constructor(
     }
 
     fun uploadCourse() {
+        _drawState.value = UiState.Loading
         launchWithHandler {
             courseRepository.uploadCourse(
                 image = _image.value!!.toFormData(),
@@ -95,9 +95,7 @@ class DrawViewModel @Inject constructor(
                     departureAddress = departureAddress,
                     departureName = departureName
                 ).toRequestBody()
-            ).onStart {
-                _drawState.value = UiState.Loading
-            }.collectResult(
+            ).collectResult(
                 onSuccess = {
                     uploadCourseId = it
                     _drawState.value = UiState.Success


### PR DESCRIPTION
## 작업 배경
- v2.3.0 디바이스 테스트 중 코스 저장 완료 버튼 클릭 시 로딩바가 표시되지 않는 현상 발견
- 기존에는 업로드 중 로딩 UI가 표시되어 사용자에게 대기를 안내했으나 미작동 상태

## 변경 사항
| 파일 | 변경 내용 |
|------|-----------|
| `DrawViewModel.kt` | `UiState.Loading` 설정 시점을 네트워크 호출 전으로 이동, 불필요한 `onStart` 연산자 및 import 제거 |

**버그 원인:**
- `courseRepository.uploadCourse()`는 `suspend fun`이라 호출 시점에 이미 네트워크 요청을 완료하고 `Flow`를 반환
- `onStart { _drawState.value = UiState.Loading }` 블록은 flow collect 시점에 실행되는데, 이 때는 이미 응답 수신 후
- Loading → Success/Failure가 동일 Main 이벤트 루프에서 연속 실행 → 로딩바가 실질적으로 0ms 표시

**수정 전:**
```kotlin
fun uploadCourse() {
    launchWithHandler {
        courseRepository.uploadCourse(...) // 여기서 네트워크 완료
            .onStart { _drawState.value = UiState.Loading } // 응답 후 실행
            .collectResult(...)
    }
}
```

**수정 후:**
```kotlin
fun uploadCourse() {
    _drawState.value = UiState.Loading // 네트워크 호출 전 즉시 표시
    launchWithHandler {
        courseRepository.uploadCourse(...)
            .collectResult(...)
    }
}
```

## 영향 범위
- `DrawViewModel.uploadCourse()` 메서드만 영향
- 로딩바 표시 타이밍이 네트워크 호출 시작 전으로 변경 (올바른 동작)
- 기능 동작 자체(업로드 성공/실패 처리)는 변경 없음

## Test Plan
- [x] 코드 로직 검증 (suspend fun + Flow 실행 순서 분석)
- [ ] 기기에서 코스 그리기 → 저장 버튼 클릭 → 로딩바 표시 확인
- [ ] 업로드 성공/실패 시 로딩바 정상 종료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)