### PR TITLE
feat: 코스발견 배너를 Firestore 대신 서버 API에서 받아오도록 전환

### DIFF
--- a/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseGetBanner.kt
+++ b/app/src/main/java/com/runnect/runnect/data/dto/response/ResponseGetBanner.kt
@@ -1,0 +1,20 @@
+package com.runnect.runnect.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseGetBanner(
+    @SerialName("banners")
+    val banners: List<Banner>
+) {
+    @Serializable
+    data class Banner(
+        @SerialName("index")
+        val index: Int,
+        @SerialName("imageUrl")
+        val imageUrl: String,
+        @SerialName("linkUrl")
+        val linkUrl: String
+    )
+}

--- a/app/src/main/java/com/runnect/runnect/data/service/BannerService.kt
+++ b/app/src/main/java/com/runnect/runnect/data/service/BannerService.kt
@@ -1,0 +1,10 @@
+package com.runnect.runnect.data.service
+
+import com.runnect.runnect.data.dto.response.ResponseGetBanner
+import retrofit2.http.GET
+
+interface BannerService {
+
+    @GET("/api/banner")
+    suspend fun getBanners(): Result<ResponseGetBanner>
+}

--- a/app/src/main/java/com/runnect/runnect/data/source/remote/RemoteBannerDataSource.kt
+++ b/app/src/main/java/com/runnect/runnect/data/source/remote/RemoteBannerDataSource.kt
@@ -1,41 +1,25 @@
 package com.runnect.runnect.data.source.remote
 
-import com.google.firebase.firestore.FirebaseFirestore
+import com.runnect.runnect.data.service.BannerService
 import com.runnect.runnect.domain.entity.DiscoverBanner
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
 import timber.log.Timber
 import javax.inject.Inject
 
 class RemoteBannerDataSource @Inject constructor(
-    private val bannerService: FirebaseFirestore
+    private val bannerService: BannerService
 ) {
-    private val banners = mutableListOf<DiscoverBanner>()
+    fun getDiscoverBanners(): Flow<MutableList<DiscoverBanner>> = flow {
+        val banners = bannerService.getBanners().getOrThrow().banners.map { banner ->
+            DiscoverBanner(
+                index = banner.index,
+                imageUrl = banner.imageUrl,
+                linkUrl = banner.linkUrl
+            )
+        }.toMutableList()
 
-    fun getDiscoverBanners(): Flow<MutableList<DiscoverBanner>> = callbackFlow {
-        bannerService.collection("data")
-            .addSnapshotListener { querySnapshot, exception ->
-                if (exception != null) {
-                    Timber.e("Firebase Firestore Exception: ${exception.message}")
-                    return@addSnapshotListener
-                }
-
-                if (querySnapshot != null) {
-                    banners.clear()
-                    for (document in querySnapshot) {
-                        banners.add(
-                            DiscoverBanner(
-                                index = document.getLong("index")!!.toInt(),
-                                imageUrl = document.getString("imageUrl").toString(),
-                                linkUrl = document.getString("linkUrl").toString()
-                            )
-                        )
-                    }
-                    Timber.d("SUCCESS GET DISCOVER BANNERS : $banners")
-                    trySend(banners)
-                }
-            }
-        awaitClose()
+        Timber.d("SUCCESS GET DISCOVER BANNERS : $banners")
+        emit(banners)
     }
 }

--- a/app/src/main/java/com/runnect/runnect/di/ServiceModule.kt
+++ b/app/src/main/java/com/runnect/runnect/di/ServiceModule.kt
@@ -1,8 +1,6 @@
 package com.runnect.runnect.di
 
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.Firebase
-import com.google.firebase.firestore.firestore
+import com.runnect.runnect.data.service.BannerService
 import com.runnect.runnect.data.service.CourseService
 import com.runnect.runnect.data.service.LoginService
 import com.runnect.runnect.data.service.ReverseGeocodingService
@@ -46,5 +44,6 @@ object ServiceModule {
 
     @Singleton
     @Provides
-    fun provideFirebaseFirestore(): FirebaseFirestore = Firebase.firestore
+    fun providePBannerService(@RetrofitModule.RetrofitV2 retrofitV2: Retrofit) =
+        retrofitV2.create(BannerService::class.java)
 }


### PR DESCRIPTION
## 배경
코스발견 탭 상단 배너를 Firestore(`data` 컬렉션)에서 직접 구독해오던 걸, Runnect 서버에 신규 배너 API가 생겨서 그쪽으로 교체 (Runnect-Spring-Boot-Server [#209](https://github.com/Runnect/Runnect-Spring-Boot-Server/pull/209)/[#210](https://github.com/Runnect/Runnect-Spring-Boot-Server/pull/210), 이미 dev/prod 배포 및 배너 3건 등록 완료).

## 변경 사항
- `BannerService`(Retrofit) 신규 추가 — `GET /api/banner`
- `ResponseGetBanner` DTO 추가 (`{ banners: [{ index, imageUrl, linkUrl }] }`, 서버 응답과 1:1 매칭)
- `RemoteBannerDataSource`: `FirebaseFirestore` 구독 → `BannerService` 호출로 교체 (인터페이스 반환 타입 `Flow<MutableList<DiscoverBanner>>>` 그대로 유지해서 상위 `BannerRepository`/`DiscoverViewModel`/`BannerAdapter`는 변경 없음)
- `ServiceModule`: `provideFirebaseFirestore()` 제거, `providePBannerService()` 추가

## 영향 범위
`DiscoverBanner(index, imageUrl, linkUrl)` 도메인 모델과 필드가 동일해서 Repository 이상 레이어는 무변경. Firestore 실시간 구독 → 1회성 REST 호출로 바뀌지만, 기존에도 `DiscoverViewModel`이 화면 진입 시 1회만 `getDiscoverBanners()`를 호출하는 구조라 실사용 동작 차이 없음.

## 검증
- `./gradlew :app:compileDebugKotlin` 성공
- 서버 쪽은 이미 prod(`https://api.runnect.site/api/banner`)에서 실데이터 3건으로 확인 완료
- **에뮬레이터/실기기 미보유 환경이라 앱 실행을 통한 화면 검증은 못 했습니다.** 로컬에서 실행해서 코스발견 탭 배너가 정상 노출되는지 한 번 확인 부탁드려요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving banner content, including images and destination links.
  * Banner data is now loaded through the app’s web service and displayed in the Discover experience.

* **Improvements**
  * Updated banner loading to use a streamlined one-time request, improving data retrieval consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->